### PR TITLE
ci(release): Prepare Release workflow — tag/version drift can't happen again

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,190 @@
+name: Prepare Release
+
+# Run manually from the Actions tab (same flow as anyplotlib's Prepare Release).
+# Creates a branch + PR that bumps electron/package.json — the ONE hand-set
+# version string in this repo (the Python version is derived from the git tag
+# by setuptools_scm, so there is nothing to bump on that side). release.yml
+# hard-fails when the pushed tag doesn't match electron/package.json (that
+# guard is exactly what killed the v0.1.0-rc.3 release); going through this
+# workflow makes the two agree by construction, because the PR tells you the
+# one tag that will pass.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version component to bump"
+        required: true
+        type: choice
+        options:
+          - minor
+          - patch
+          - major
+          - rc       # increments the -rc.N counter on the current base version
+          - stable   # drops the -rc.N suffix: promote the current rc to stable
+      rc:
+        description: "Cut the bumped version as a release candidate (-rc.1; implied by bump=rc)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write        # push the release branch
+  pull-requests: write   # open the PR
+
+jobs:
+  prepare:
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # ── Compute the new version ──────────────────────────────────────────
+      # electron/package.json is the source of truth for the app's semver
+      # (electron-builder/electron-updater read it); the release tag must be
+      # v<that version>. Tag shapes and the stable/beta channel mapping are
+      # documented in RELEASING.md.
+      - name: Compute new version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          IS_RC: ${{ inputs.rc }}
+        run: |
+          CURRENT=$(node -p "require('./electron/package.json').version")
+          export CURRENT_VERSION="$CURRENT"
+
+          NEW_VERSION=$(python3 - <<'PYEOF'
+          import os, re, sys
+
+          current = os.environ["CURRENT_VERSION"]
+          bump    = os.environ["BUMP"]
+          is_rc   = os.environ["IS_RC"].lower() == "true"
+
+          m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$", current)
+          if not m:
+              sys.exit(f"unparseable current version: {current!r}")
+          major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+          rc_n = int(m.group(4)) if m.group(4) else None
+
+          if bump == "major":
+              major, minor, patch = major + 1, 0, 0
+          elif bump == "minor":
+              minor, patch = minor + 1, 0
+          elif bump == "patch":
+              patch += 1
+          elif bump == "rc":
+              # Keep the same base; just walk the rc counter forward.
+              is_rc = True
+              rc_n  = (rc_n or 0) + 1
+          elif bump == "stable":
+              # Promote the current rc to its stable base version.
+              if rc_n is None:
+                  sys.exit(f"bump=stable but current version {current!r} has no -rc suffix")
+              is_rc = False
+
+          if is_rc:
+              if bump != "rc":
+                  rc_n = 1          # fresh rc series for the new base
+              print(f"{major}.{minor}.{patch}-rc.{rc_n}", end="")
+          else:
+              print(f"{major}.{minor}.{patch}", end="")
+          PYEOF
+          )
+
+          echo "new_version=$NEW_VERSION"     >> "$GITHUB_OUTPUT"
+          echo "tag=v$NEW_VERSION"            >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumping (${BUMP}): $CURRENT → $NEW_VERSION"
+
+      - name: Fail if the tag already exists
+        run: |
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "::error::tag ${{ steps.version.outputs.tag }} already exists on origin"
+            exit 1
+          fi
+
+      # ── Pre-flight checks from RELEASING.md — fail HERE, not at release time ──
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # A drifted lock ships an installer that only fails on the user's first
+      # launch (the venv is resolved from uv.lock on their machine).
+      - name: Verify uv.lock is in sync with pyproject.toml
+        run: uv lock --check
+
+      # Git deps must reference explicit SHAs or tags, never moving branches —
+      # otherwise the same installer resolves different code over time.
+      - name: Verify git dependencies are pinned to SHAs or tags
+        run: |
+          bad=$(grep -nE "git\+https" pyproject.toml | grep -vE '@[0-9a-f]{40}"|@v?[0-9]+(\.[0-9]+)+[^"]*"' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::unpinned git dependencies in pyproject.toml:"
+            echo "$bad"
+            exit 1
+          fi
+
+      # ── Bump the version ─────────────────────────────────────────────────
+      # npm version updates package.json AND package-lock.json together.
+      - name: Bump electron/package.json
+        working-directory: electron
+        run: npm version "${{ steps.version.outputs.new_version }}" --no-git-tag-version
+
+      # ── Commit and push ──────────────────────────────────────────────────
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit release changes
+        run: |
+          git checkout -b "${{ steps.version.outputs.branch }}"
+          git add electron/package.json electron/package-lock.json
+          git commit -m "chore: prepare release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.branch }}"
+
+      # ── Open pull request ────────────────────────────────────────────────
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "Release ${TAG}" \
+            --base  main \
+            --head  "${BRANCH}" \
+            --body  "## Release ${TAG}
+
+          > Auto-generated by the **Prepare Release** workflow.
+
+          ### What changed
+          - \`electron/package.json\` (+ lockfile) bumped to \`${TAG#v}\` — this is the
+            version electron-builder/electron-updater use, and \`release.yml\` refuses
+            to build a tag that doesn't match it
+          - Pre-flight checks passed: \`uv lock --check\`, git deps pinned to SHAs/tags
+
+          ### Review checklist
+          - [ ] Version is correct in \`electron/package.json\`
+          - [ ] Manual checks from RELEASING.md done on a real machine (GPU path,
+            distributed navigator, clean shutdown)
+          - [ ] CI passes
+
+          ### After merging
+          Tag **the merge commit on main** — the tag MUST be exactly \`${TAG}\`:
+          \`\`\`bash
+          git fetch origin
+          git tag ${TAG} origin/main
+          git push origin ${TAG}
+          \`\`\`
+          The tag push triggers \`release.yml\` (3-platform build → draft release →
+          publish once all legs pass)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,10 @@ jobs:
       # drift here would ship an installer electron-updater can't reason about
       # correctly (or a release that silently doesn't offer itself as an
       # update). Fail fast rather than publish a mismatched build.
+      # shell: bash is load-bearing — the windows-latest default is PowerShell,
+      # which can't parse this script (ParserError, killed the v0.1.0 run).
       - name: Verify electron/package.json version matches the pushed tag
+        shell: bash
         run: |
           pkg_version=$(node -p "require('./electron/package.json').version")
           tag_version="${{ needs.channel.outputs.version }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,10 @@
 # Releasing SpyDE
 
-The single checklist for cutting a SpyDE release. The version is **derived from
-the git tag** (`setuptools_scm`), so tagging is the act that sets the version —
-there is no version string to bump by hand.
+The single checklist for cutting a SpyDE release. The Python version is
+**derived from the git tag** (`setuptools_scm`), so tagging is the act that sets
+it. The one hand-maintained version string is `electron/package.json` — and the
+**Prepare Release** workflow (`.github/workflows/prepare_release.yml`) bumps it
+for you, so nothing is edited by hand in practice.
 
 ## Versioning model
 
@@ -82,17 +84,33 @@ Run from a clean checkout of the commit you intend to tag.
    - **Clean shutdown** — quit the app; confirm no orphaned `python.exe` / Dask
      worker processes remain (Task Manager / `ps`).
 
-7. **Versions agree** — `electron/package.json` `version` should match the tag you
-   are about to cut (it is set by hand; keep it in step with the Python tag).
-   `release.yml`'s `build` job now enforces this and fails the release if they
-   drift, but fix it before tagging rather than relying on that as your check.
+7. **Versions agree** — `electron/package.json` `version` must match the tag you
+   are about to cut. Don't bump it by hand: run the **Prepare Release** workflow
+   (below), which bumps it in a reviewable PR. `release.yml`'s `build` job
+   enforces the match and fails the release if they drift (this is exactly how
+   the `v0.1.0-rc.3` release died: tag `-rc.3`, package.json `0.1.0`).
 
 ## Cutting the release
 
-```bash
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
+1. **Run the Prepare Release workflow** (Actions tab → *Prepare Release* → *Run
+   workflow*). Pick the bump: `major` / `minor` / `patch` (optionally as an
+   `-rc.1` via the checkbox), `rc` (next `-rc.N` on the current base), or
+   `stable` (drop the `-rc` suffix — promote the current rc). It bumps
+   `electron/package.json` (+ lockfile), runs the lockfile/pin pre-flight
+   checks, and opens a `release/vX.Y.Z` PR.
+
+   > Exception: if `electron/package.json` already equals the version you want
+   > to tag (no bump needed), skip straight to tagging.
+
+2. **Review and merge the PR** — CI runs the full matrix on it.
+
+3. **Tag the merge commit with exactly the tag named in the PR** and push:
+
+   ```bash
+   git fetch origin
+   git tag vX.Y.Z origin/main
+   git push origin vX.Y.Z
+   ```
 
 The tag triggers `.github/workflows/release.yml`, which builds the Electron app +
 uv-managed Python sidecar on Windows / macOS / Linux in parallel and publishes a


### PR DESCRIPTION
## What

Adds `.github/workflows/prepare_release.yml` (modeled on anyplotlib's) and routes RELEASING.md's version-bump step through it.

## Why

The `v0.1.0-rc.3` release failed on `release.yml`'s version guard: the tag said `-rc.3` while `electron/package.json` said `0.1.0`. That package.json field is the one hand-set version in the repo (Python is setuptools_scm-derived from the tag), so drift = dead release.

## How it works

Actions tab → **Prepare Release** → pick a bump (`major`/`minor`/`patch`, optional rc checkbox; `rc` = next `-rc.N`; `stable` = promote the current rc). The workflow:
- computes the new version from `electron/package.json`
- fails fast if the target tag already exists
- runs the RELEASING.md pre-flight checks (`uv lock --check`, git deps pinned to SHAs/tags)
- bumps `electron/package.json` + lockfile via `npm version --no-git-tag-version`
- opens a `release/vX.Y.Z` PR whose body names the exact tag to push after merging

