### PR TITLE
fix(release): publish to the repo the workflow runs in (directelectron org doesn't exist yet)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,9 +174,16 @@ jobs:
       # electron-updater's autoUpdater reads at runtime — publish:false builds
       # never generate these files at all. Unsigned for now — signing secrets
       # are a follow-up (PACKAGING.md "What's intentionally deferred").
+      # -c.publish.owner/.repo pin the publish target to THE REPO THIS WORKFLOW
+      # RUNS IN — the same-repo assumption the draft-release design above already
+      # makes (GITHUB_TOKEN can't publish cross-repo anyway). Without the
+      # override, electron-builder.yml's static owner decides, and a value that
+      # doesn't match this repo 404s the whole build (v0.1.0 died publishing to
+      # the not-yet-existing directelectron org). Survives a future repo
+      # transfer with zero edits.
       - name: Build + publish desktop app
         working-directory: electron
-        run: npm run dist -- --publish always
+        run: npm run dist -- --publish always -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=${{ github.event.repository.name }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -69,7 +69,12 @@ linux:
 # `--publish always` so these get generated and uploaded; this block alone does
 # NOT publish anything (a local `npm run dist` without --publish never touches
 # GitHub).
+# The owner/repo here is where a LOCAL build's app-update.yml points; release.yml
+# overrides both to the repo the workflow runs in (-c.publish.owner/.repo), which
+# is what keeps CI publishing working before AND after the planned transfer to the
+# directelectron org (README/pyproject already point there, but that repo does not
+# exist yet — publishing to it 404s, which is what killed the v0.1.0 release).
 publish:
   provider: github
-  owner: directelectron
+  owner: CSSFrancis
   repo: spyde


### PR DESCRIPTION
## What killed the v0.1.0 rebuild

electron-builder hit `GET /repos/directelectron/spyde/releases` → **404**: `electron-builder.yml`'s publish block points at the planned org home, which doesn't exist yet. (Even when it does, the workflow's `GITHUB_TOKEN` can't publish cross-repo — `release.yml`'s draft-first design already assumes same-repo.)

## Fix

- `release.yml` passes `-c.publish.owner=${{ github.repository_owner }} -c.publish.repo=${{ github.event.repository.name }}` — publishing always targets the repo the workflow runs in, so it works today on CSSFrancis and keeps working unchanged after a transfer to `directelectron`.
- `electron-builder.yml` static owner → `CSSFrancis` so local builds' `app-update.yml` points where releases actually live today.

## Verified locally (Windows)

Full `npm run dist` with `-c.publish.owner=OVERRIDETEST -c.publish.repo=overriderepo`: build succeeds end-to-end (NSIS installer + blockmap), and the baked `resources/app-update.yml` contains the override values — the `-c` dot-notation merges correctly with `--config electron-builder.yml`. This also re-validates the Windows packaging leg post-PR#3, which no CI run had completed.

## After merging

I'll retag `v0.1.0` on the merge commit (old tag already deleted) and watch the release run.

