### PR TITLE
ci(release): default the build job to bash — second pwsh casualty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,14 @@ jobs:
     needs: [channel, prepare-release]
     permissions:
       contents: write      # electron-builder publishes assets to the release
+    # windows-latest's default step shell is PowerShell, which killed two
+    # v0.1.0 attempts (ParserError on the bash version-guard script; then
+    # npm.cmd arg-mangling that turned -c.publish.repo=spyde into a config
+    # FILE path → ENOENT). Every run step in this job is a POSIX script or a
+    # command verified under Git Bash on Windows, so default the whole job.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: true        # abort all legs if one fails — keeps releases clean
       matrix:
@@ -123,10 +131,7 @@ jobs:
       # drift here would ship an installer electron-updater can't reason about
       # correctly (or a release that silently doesn't offer itself as an
       # update). Fail fast rather than publish a mismatched build.
-      # shell: bash is load-bearing — the windows-latest default is PowerShell,
-      # which can't parse this script (ParserError, killed the v0.1.0 run).
       - name: Verify electron/package.json version matches the pushed tag
-        shell: bash
         run: |
           pkg_version=$(node -p "require('./electron/package.json').version")
           tag_version="${{ needs.channel.outputs.version }}"


### PR DESCRIPTION
## What killed attempt 3 (so close — ubuntu published its assets!)

Windows leg only: under the pwsh default shell, `-c.publish.repo=spyde` gets mangled on the way through `npm.cmd` — electron-builder received it split and tried to open a config **file** named `.publish.repo=spyde` → ENOENT. The identical command works under Git Bash on Windows (my local validation ran there, which is why it passed locally) and on the ubuntu leg, which built and published `SpyDE-0.1.0.AppImage` + `latest-linux.yml` to the draft this run. macOS was mid-publish when fail-fast cancelled it.

## Fix

Job-level `defaults.run.shell: bash` on the `build` job (replacing the per-step `shell: bash` from #5) — two pwsh casualties in two runs is a class of bug, not an instance. Every run step in the job is POSIX or Git-Bash-verified.

## After merging

I'll retag `v0.1.0` (old tag deleted again) and watch the run. The draft already holds the linux/mac assets; electron-builder overwrites same-name assets on draft releases, so the re-run converges.