### PR TITLE
build: bump anyplotlib pin to released 0.3.0

### DIFF
--- a/electron/tests/_harness.cjs
+++ b/electron/tests/_harness.cjs
@@ -284,12 +284,19 @@ function navWindows(page) {
  *    viz_main_impl.cc "Exiting GPU process", command_buffer_proxy_impl.cc)
  *    and is infrastructure noise, not a SpyDE error. Python backend lines
  *    never match that shape, so real errors still fail the audit.
+ *  - "Failed to create WebGPU Context Provider" — Chromium emits this from the
+ *    figure iframe whenever the runner has no usable WebGPU adapter (every
+ *    hosted CI runner under xvfb). anyplotlib falls back to Canvas2D and the
+ *    render is still correct (the GPU render math is covered separately in
+ *    anyplotlib's own --enable-unsafe-webgpu suite), so it is benign here. A
+ *    real backend error is a Python traceback, never this renderer line.
  */
 function backendErrorLines(backend) {
   return backend.logBuffer.filter((l) =>
     /ERROR|Traceback/i.test(l)
     && !/Security Warning|Content.Security.Policy|Content Security/i.test(l)
     && !/willReadFrequently/i.test(l)
+    && !/Failed to create WebGPU Context Provider/i.test(l)
     && !/:(ERROR|FATAL):[a-z_0-9]+\.(cc|mm)\(\d+\)/.test(l))
 }
 

--- a/electron/tests/ipf_perf.spec.ts
+++ b/electron/tests/ipf_perf.spec.ts
@@ -339,6 +339,9 @@ test('IPF raster/GPU render paths render correctly in the real app', async () =>
   const gpuLogLines = backendLog.filter((l) => /gpu|webgpu|scatter3d/i.test(l))
   const tbLines = backendLog.filter((l) =>
     /Traceback|ERROR/.test(l) && !/Security Warning|willReadFrequently/.test(l)
+    // Benign on adapter-less CI runners — anyplotlib falls back to Canvas2D and
+    // the render is still correct (see backendErrorLines in _harness.cjs).
+    && !/Failed to create WebGPU Context Provider/i.test(l)
     && !/:(ERROR|FATAL):[a-z_0-9]+\.(cc|mm)\(\d+\)/.test(l))
   console.log('[ipf_perf] renderer gpu warnings:',
     gpuWarns.slice(-8).join(' | ') || '(none)')

--- a/electron/tests/report_sidebar.spec.ts
+++ b/electron/tests/report_sidebar.spec.ts
@@ -263,15 +263,20 @@ test('6) save to an explicit path and validate the zip contents', async () => {
     timeout: 10_000, message: 'report file was never written',
   }).toBe(true)
 
-  // Unzip via bsdtar (Windows tar handles zip) into the work dir. Resolve the
-  // System32 binary explicitly on Windows: a bare 'tar' can resolve to git's
-  // GNU tar depending on the spawning shell's PATH, and GNU tar treats the
-  // drive-letter in an absolute 'C:\...' path as a remote-host prefix.
-  const tarExe = process.platform === 'win32'
-    ? join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'tar.exe')
-    : 'tar'
-  execFileSync(tarExe, ['-xf', reportPath, '-C', workDir], { stdio: 'pipe' })
-  // tar extracts report.md / figures/ / assets/ under workDir.
+  // A .spyde-report is a ZIP. Extract it into the work dir. Picking the right
+  // extractor is per-platform: on Windows bsdtar reads zip, but we must resolve
+  // the System32 binary explicitly — a bare 'tar' can resolve to git's GNU tar
+  // depending on the spawning shell's PATH, and GNU tar treats the drive-letter
+  // in an absolute 'C:\...' path as a remote-host prefix. On Linux/macOS the
+  // system 'tar' is GNU tar, which CANNOT read a zip ("does not look like a tar
+  // archive") — use 'unzip' (preinstalled on the GitHub Ubuntu runners) there.
+  if (process.platform === 'win32') {
+    const tarExe = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'tar.exe')
+    execFileSync(tarExe, ['-xf', reportPath, '-C', workDir], { stdio: 'pipe' })
+  } else {
+    execFileSync('unzip', ['-o', '-q', reportPath, '-d', workDir], { stdio: 'pipe' })
+  }
+  // The extractor writes report.md / figures/ / assets/ under workDir.
   const mdPath = join(workDir, 'report.md')
   expect(existsSync(mdPath)).toBe(true)
   const md = readFileSync(mdPath, 'utf-8')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "imageio-ffmpeg",
     "imagecodecs",
     "psygnal>=0.10.0",
-    "anyplotlib>=0.3.0b1",
+    "anyplotlib>=0.3.0",
     "pyyaml",
     # GPU-accelerated batched compute (vector orientation mapping, etc.).
     "torch",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "anyplotlib"
-version = "0.3.0b1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anywidget" },
@@ -45,9 +45,9 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/6a/9b81063a4a9d243fe8a3206292313a97e1727948923e564e022462507383/anyplotlib-0.3.0b1.tar.gz", hash = "sha256:38f19ce97d2285c3a133e24d2a5f00e7ccc8ee81710cd48c4e43d9f8e5970f0c", size = 1347256, upload-time = "2026-07-13T22:31:46.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/38/70ffcdd5ca1134e9119233bc66cd015ddda0bf50682b4e7b4d691b1ba98e/anyplotlib-0.3.0.tar.gz", hash = "sha256:f62bc3d9b1547809e76ba7ccad228579b6ad0a07e6f0fa3a33c1480adf6e8cf4", size = 1391259, upload-time = "2026-07-14T17:42:04.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/8a/f49c3944e369870b303144d88307ec1dea6c7f98a66568e10bc4a4a6b90f/anyplotlib-0.3.0b1-py3-none-any.whl", hash = "sha256:0f1842d8da1b32eb183e7bba7fbe6945923b405ab3820f899192d87cc91cb66d", size = 265997, upload-time = "2026-07-13T22:31:44.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b9/b2fde3700eb5efee430fb770fe8a7919580603dabad51176c6979851b2c6/anyplotlib-0.3.0-py3-none-any.whl", hash = "sha256:d88b39e03bf3d9ffbbc4ec4cb0cfdd60e27837a7bd7fc8e495117f22f2b57601", size = 270195, upload-time = "2026-07-14T17:42:02.507Z" },
 ]
 
 [[package]]
@@ -3811,7 +3811,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyplotlib", specifier = ">=0.3.0b1" },
+    { name = "anyplotlib", specifier = ">=0.3.0" },
     { name = "bokeh" },
     { name = "dask" },
     { name = "distributed" },


### PR DESCRIPTION
## What

anyplotlib **0.3.0** is now released on PyPI. This bumps the dependency from the `0.3.0b1` beta to the release and re-locks, and fixes three pre-existing e2e failures on the base branch.

### 1. Dependency bump
- `pyproject.toml`: `anyplotlib>=0.3.0b1` → `>=0.3.0`
- `uv.lock`: re-locked — anyplotlib resolves to `0.3.0` from the PyPI **registry** (released sdist/wheel + hashes), no editable path source.

### 2. e2e fixes (3 pre-existing failures, unrelated to the bump)
The `feat/report-phase1` e2e run (`29355241537`, still on `0.3.0b1`) was red on three specs. All were environmental / test-harness bugs, not product regressions, and none are caused by the anyplotlib bump:

- **`ipf_perf` + `movie_export`** — the backend-error audits tripped on `[spyde RENDERER-ERROR] Failed to create WebGPU Context Provider`, a benign warning Chromium emits from the figure iframe whenever the runner has no usable WebGPU adapter (every hosted CI runner under xvfb). anyplotlib falls back to Canvas2D and the render is still correct. Fix: exclude this line in `backendErrorLines` (`_harness.cjs`) and in `ipf_perf`'s inline traceback filter — matching the existing exclusions for CSP / `willReadFrequently` / Chromium `.cc(line)` noise. A real Python traceback is never this renderer line, so real errors still fail the audit.
- **`report_sidebar` #6** — extracted the `.spyde-report` with `tar -xf`, but the container is a **ZIP** (`PK` magic); GNU tar on the Linux runner rejects it. Fix: use `unzip` on Linux/macOS (bsdtar reads zip on Windows, so that branch is unchanged).

Stacked on `feat/report-phase1` (the report-builder branch, PR #8) since that branch is what depends on the 0.3.0 tile/annotation features and carries these specs. This clears the "bump anyplotlib pin before merge" item.

## Verification

- `uv lock` → `Updated anyplotlib v0.3.0b1 -> v0.3.0`; `uv sync --frozen` builds a clean venv
- anyplotlib 0.3.0, `_electron`, `spyde.backend.app`, the tile backend, and all `spyde/actions/report/*` import cleanly (no API break beta→release)
- Full report-builder pytest suite: **171 passed**
- **e2e fixes verified without CI:** `backendErrorLines` fed the exact failing CI log lines → WebGPU lines excluded, a real `Traceback ... ValueError` still caught, Chromium noise still excluded. A real `write_report()` `.spyde-report` (`PK\x03\x04`) reproduced the `tar` failure, then `unzip -o -q` extracted the expected `report.md`/`figures/`/`assets/` layout (exit 0). Both edited specs are TS-syntax-clean.

> Note: `build.yml`'s e2e job only triggers on PRs **into `main`**, so it does not run on this PR (which targets `feat/report-phase1`). These fixes take effect when `feat/report-phase1` runs against main (PR #8). The e2e job is also `continue-on-error: true` (non-blocking).