### PR TITLE
feat(ui): floating first-run setup overlay with live progress

### DIFF
--- a/electron/src/main/envProgress.ts
+++ b/electron/src/main/envProgress.ts
@@ -1,0 +1,126 @@
+/**
+ * envProgress.ts — parse `uv` first-run output into structured setup progress.
+ *
+ * `uv sync` / `uv pip install` stream human-readable status to stderr. On first
+ * packaged launch that stream is the ONLY signal that anything is happening
+ * (hundreds of MB of wheels, incl. PyTorch, are being fetched). The renderer
+ * turns these events into a floating "Setting up…" overlay with a live phase,
+ * a friendly current-step line, an optional download %, and a raw log tail —
+ * so first launch never looks frozen.
+ *
+ * This module is pure string→event, no I/O, so it is unit-testable
+ * (test_env_progress.ts) without spawning uv.
+ */
+
+export type EnvPhase =
+  | 'resolving'    // building the dependency graph
+  | 'downloading'  // fetching wheels/sdists
+  | 'installing'   // unpacking into the venv
+  | 'building'     // building the editable spyde package (setuptools_scm)
+  | 'torch'        // the per-machine torch step (the big one)
+  | 'working'      // fallback: uv said something we don't specifically classify
+
+export interface EnvProgressEvent {
+  phase: EnvPhase
+  /** Short human sentence for the overlay's headline step, e.g. "Downloading PyTorch". */
+  step: string
+  /** 0–100 when uv reports a download percentage for a large artifact; else null. */
+  percent: number | null
+}
+
+const KNOWN_BIG = /\btorch\b/i
+
+/**
+ * Classify ONE raw line of uv output. Returns null for noise (blank lines,
+ * lines we can't meaningfully turn into a step) — the caller keeps the last
+ * non-null event as the current state and always appends the raw line to the
+ * log tail regardless.
+ */
+export function parseUvLine(raw: string): EnvProgressEvent | null {
+  const line = raw.replace(/\r/g, '').trim()
+  if (!line) return null
+
+  // Our own [env-setup] breadcrumbs (pythonEnv.ts) — use them verbatim, they're
+  // already user-facing phase announcements.
+  if (line.startsWith('[env-setup]')) {
+    const msg = line.slice('[env-setup]'.length).trim()
+    // Order matters: the "two-step install … torch deferred" breadcrumb mentions
+    // torch but announces the RESOLVE phase, so match the sync/plan keywords
+    // first and only fall to the torch phase for an actual torch-install line.
+    if (/two-step|full locked|uv sync|deferred/i.test(msg)) {
+      return { phase: 'resolving', step: 'Preparing the analysis environment', percent: null }
+    }
+    if (/torch/i.test(msg)) {
+      return { phase: 'torch', step: 'Installing PyTorch for your GPU', percent: null }
+    }
+    return { phase: 'working', step: capitalize(msg), percent: null }
+  }
+
+  // A download progress line. uv renders these like:
+  //   "torch     ======>          123.4 MiB/825.0 MiB"  (bar form), or
+  //   "Downloading torch (825.0 MiB)"                    (start), or a trailing
+  //   percentage. Pull a percent if the two sizes are present.
+  const dl = line.match(/^([\w.\-]+)\s+.*?([\d.]+)\s*([KMG]i?B)\s*\/\s*([\d.]+)\s*([KMG]i?B)/i)
+  if (dl) {
+    const pkg = dl[1]
+    const cur = toBytes(dl[2], dl[3])
+    const tot = toBytes(dl[4], dl[5])
+    const percent = tot > 0 ? Math.min(100, Math.round((cur / tot) * 100)) : null
+    const big = KNOWN_BIG.test(pkg)
+    return {
+      phase: big ? 'torch' : 'downloading',
+      step: big ? 'Downloading PyTorch' : `Downloading ${pkg}`,
+      percent,
+    }
+  }
+
+  // uv's phase verbs (it prints "Resolved N packages", "Downloaded …",
+  // "Prepared …", "Installed N packages", "Building …").
+  if (/^Resolv(ing|ed)\b/i.test(line)) {
+    return { phase: 'resolving', step: 'Resolving dependencies', percent: null }
+  }
+  if (/^Download(ing|ed)\b/i.test(line)) {
+    const m = line.match(/^Download(?:ing|ed)\s+([\w.\-]+)/i)
+    const pkg = m?.[1]
+    const big = pkg ? KNOWN_BIG.test(pkg) : false
+    return {
+      phase: big ? 'torch' : 'downloading',
+      step: big ? 'Downloading PyTorch' : (pkg ? `Downloading ${pkg}` : 'Downloading packages'),
+      percent: null,
+    }
+  }
+  if (/^Prepar(ing|ed)\b/i.test(line)) {
+    return { phase: 'installing', step: 'Preparing packages', percent: null }
+  }
+  if (/^Install(ing|ed)\b/i.test(line)) {
+    const m = line.match(/(\d+)\s+packages?/i)
+    return {
+      phase: 'installing',
+      step: m ? `Installing ${m[1]} packages` : 'Installing packages',
+      percent: null,
+    }
+  }
+  if (/^Building\b/i.test(line) || /setuptools[_-]scm|Building wheel|Building editable/i.test(line)) {
+    return { phase: 'building', step: 'Building the SpyDE package', percent: null }
+  }
+  if (/^Audit(ing|ed)\b/i.test(line)) {
+    return { phase: 'installing', step: 'Finalizing the environment', percent: null }
+  }
+
+  // Recognized-but-unclassified: keep the phase we can't infer as generic
+  // "working" so the overlay still updates its step text and never looks stuck.
+  return { phase: 'working', step: 'Working', percent: null }
+}
+
+function toBytes(n: string, unit: string): number {
+  const v = parseFloat(n)
+  const u = unit.toUpperCase()
+  if (u.startsWith('G')) return v * 1024 ** 3
+  if (u.startsWith('M')) return v * 1024 ** 2
+  if (u.startsWith('K')) return v * 1024
+  return v
+}
+
+function capitalize(s: string): string {
+  return s ? s[0].toUpperCase() + s.slice(1) : s
+}

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -17,6 +17,7 @@ import {
 import {
   resolvePythonEnv, managedEnvPaths, installTorchPerMachine, readLockedTorchVersion,
 } from './pythonEnv'
+import { parseUvLine } from './envProgress'
 import {
   initUpdater, checkForUpdates, downloadUpdate, quitAndInstall,
   readUpdateChannel, setUpdateChannel, getLastUpdateStatus, updatesSupported,
@@ -261,16 +262,35 @@ app.whenReady().then(async () => {
   // where spyde's pyproject.toml lives (so `uv run` resolves the right env).
   const projectRoot = join(__dirname, '..', '..', '..')
   envSetupInProgress = true
+  // Whether a real first-run setup actually ran (uv emitted output). Only THEN
+  // do we tell the renderer to raise/lower the floating setup overlay — a warm
+  // launch (env already built) resolves instantly with no onProgress calls, so
+  // the overlay must never flash.
+  let envSetupStarted = false
   const resolved = await resolvePythonEnv({
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
     projectRoot,
     userData: app.getPath('userData'),
-    onProgress: (line) => {
-      process.stderr.write(`[uv] ${line}`)
-      // Surface first-run env setup in the UI (the stream/log channel).
-      win?.webContents.send('spyde:stream', line, 'stderr')
-      sendToRenderer({ type: 'status', text: 'Setting up Python environment…' })
+    onProgress: (chunk) => {
+      process.stderr.write(`[uv] ${chunk}`)
+      // Keep feeding the raw stream/log channel (Raw output view, crash overlay).
+      win?.webContents.send('spyde:stream', chunk, 'stderr')
+      if (!envSetupStarted) {
+        envSetupStarted = true
+        sendToRenderer({ type: 'env_setup', event: 'start' })
+      }
+      // Parse each line into a structured step + push the raw line to the
+      // overlay's live tail, so first-run setup shows real, moving progress
+      // instead of a single frozen "Setting up…" string.
+      for (const line of chunk.split('\n')) {
+        if (!line.trim()) continue
+        const p = parseUvLine(line)
+        sendToRenderer({
+          type: 'env_setup', event: 'progress', raw: line.replace(/\r/g, ''),
+          phase: p?.phase, step: p?.step, percent: p?.percent ?? null,
+        })
+      }
     },
   }).catch((err) => {
     const detail = err?.message ?? String(err)
@@ -300,6 +320,14 @@ app.whenReady().then(async () => {
   })
 
   envSetupInProgress = false
+
+  // Tear down the floating setup overlay once setup finishes (success OR the
+  // dev-fallback path). On the packaged failure path `resolved` is null and the
+  // blocking backend_exited overlay takes over instead, so only emit `done`
+  // when we actually have a resolved env to launch.
+  if (envSetupStarted && resolved) {
+    sendToRenderer({ type: 'env_setup', event: 'done' })
+  }
 
   // Packaged env-setup failure: overlay is up, do not spawn a doomed backend.
   if (!resolved) return

--- a/electron/src/renderer/src/components/EnvSetupOverlay.tsx
+++ b/electron/src/renderer/src/components/EnvSetupOverlay.tsx
@@ -1,0 +1,171 @@
+/**
+ * EnvSetupOverlay.tsx — the floating "Setting up SpyDE" card shown on first
+ * packaged launch while `uv sync` builds the Python environment (hundreds of MB,
+ * incl. PyTorch). Before this, first launch showed a single static "Setting up
+ * Python environment…" line with a blank canvas for minutes — indistinguishable
+ * from a hang. This overlay is driven by real parsed uv progress (EnvSetupState
+ * in SpyDEContext): a spinner, the current phase, a friendly step line, a real
+ * download % when uv reports one (indeterminate otherwise), and a live scrolling
+ * tail of the raw uv output so it is always visibly moving.
+ */
+import { useEffect, useRef } from 'react'
+import type { EnvSetupState, EnvPhase } from '../kernel/SpyDEContext'
+
+const ACCENT = '#89b4fa'
+
+const PHASES: Array<{ key: EnvPhase | 'torch'; label: string }> = [
+  { key: 'resolving', label: 'Resolve' },
+  { key: 'downloading', label: 'Download' },
+  { key: 'torch', label: 'PyTorch' },
+  { key: 'installing', label: 'Install' },
+  { key: 'building', label: 'Build' },
+]
+
+// Order used to decide which phase pills are "done" vs "upcoming".
+const PHASE_ORDER: EnvPhase[] = ['resolving', 'downloading', 'torch', 'installing', 'building']
+
+function phaseIndex(p: EnvPhase): number {
+  const i = PHASE_ORDER.indexOf(p)
+  return i < 0 ? 0 : i
+}
+
+export function EnvSetupOverlay({ setup }: { setup: EnvSetupState }) {
+  const tailRef = useRef<HTMLDivElement>(null)
+  // Keep the log tail pinned to the newest line.
+  useEffect(() => {
+    const el = tailRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [setup.lines])
+
+  const active = setup.phase === 'working' ? 'resolving' : setup.phase
+  const activeIdx = phaseIndex(active)
+  const tail = setup.lines.slice(-14)
+
+  return (
+    <div
+      data-testid="env-setup-overlay"
+      style={{
+        position: 'fixed', inset: 0, zIndex: 99998,
+        background: 'rgba(17,17,27,0.72)', backdropFilter: 'blur(2px)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 24, userSelect: 'text',
+      }}
+    >
+      <div style={{
+        maxWidth: 560, width: '100%',
+        display: 'flex', flexDirection: 'column',
+        padding: '26px 30px', borderRadius: 12,
+        background: '#1e1e2e', border: `1px solid ${ACCENT}`,
+        boxShadow: '0 12px 40px rgba(0,0,0,0.5)',
+        color: '#cdd6f4', fontFamily: 'system-ui, sans-serif',
+      }}>
+        {/* Header: spinner + title */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 6 }}>
+          <Spinner />
+          <div style={{ fontSize: 18, fontWeight: 600 }}>Setting up SpyDE</div>
+        </div>
+
+        <div style={{ fontSize: 13, lineHeight: 1.5, color: '#a6adc8', marginBottom: 16 }}>
+          First launch only — downloading the analysis environment (about 1–2&nbsp;GB,
+          including PyTorch). This can take a few minutes on a fast connection; every
+          later launch is instant.
+        </div>
+
+        {/* Phase pills */}
+        <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
+          {PHASES.map((p) => {
+            const idx = phaseIndex(p.key as EnvPhase)
+            const state = idx < activeIdx ? 'done' : idx === activeIdx ? 'active' : 'todo'
+            return (
+              <span key={p.key} style={{
+                fontSize: 11, padding: '3px 9px', borderRadius: 999,
+                border: `1px solid ${state === 'todo' ? '#313244' : ACCENT}`,
+                background: state === 'active' ? ACCENT : state === 'done' ? '#313244' : 'transparent',
+                color: state === 'active' ? '#11111b' : state === 'done' ? '#cdd6f4' : '#6c7086',
+                fontWeight: state === 'active' ? 600 : 400,
+              }}>
+                {state === 'done' ? '✓ ' : ''}{p.label}
+              </span>
+            )
+          })}
+        </div>
+
+        {/* Current step + progress bar */}
+        <div
+          data-testid="env-setup-step"
+          style={{ fontSize: 14, fontWeight: 500, marginBottom: 8 }}
+        >
+          {setup.step}{setup.percent != null ? ` — ${setup.percent}%` : '…'}
+        </div>
+        <ProgressBar percent={setup.percent} />
+
+        {/* Live raw log tail */}
+        <div style={{
+          marginTop: 16, fontSize: 10.5, color: '#6c7086',
+          textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 5,
+        }}>
+          Setup log
+        </div>
+        <div
+          ref={tailRef}
+          data-testid="env-setup-log"
+          style={{
+            height: 128, overflow: 'auto',
+            background: '#11111b', border: '1px solid #313244', borderRadius: 6,
+            padding: '7px 10px',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 11, lineHeight: 1.55, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+          }}
+        >
+          {tail.length === 0
+            ? <span style={{ color: '#6c7086', fontStyle: 'italic' }}>Starting…</span>
+            : tail.map((l, i) => (
+                <div key={i} style={{ color: '#a6adc8' }}>{l.replace(/\n$/, '')}</div>
+              ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Indeterminate when percent is null; a filled bar when we have a %. */
+function ProgressBar({ percent }: { percent: number | null }) {
+  const indeterminate = percent == null
+  return (
+    <div style={{
+      position: 'relative', height: 6, borderRadius: 3, overflow: 'hidden',
+      background: '#313244',
+    }}>
+      <div style={indeterminate
+        ? {
+            position: 'absolute', top: 0, bottom: 0, width: '35%',
+            background: ACCENT, borderRadius: 3,
+            animation: 'spyde-env-indeterminate 1.15s ease-in-out infinite',
+          }
+        : {
+            position: 'absolute', top: 0, bottom: 0, left: 0,
+            width: `${Math.max(2, percent)}%`,
+            background: ACCENT, borderRadius: 3,
+            transition: 'width 0.25s ease',
+          }
+      } />
+      <style>{`
+        @keyframes spyde-env-indeterminate {
+          0%   { left: -35%; }
+          100% { left: 100%; }
+        }
+        @keyframes spyde-env-spin { to { transform: rotate(360deg); } }
+      `}</style>
+    </div>
+  )
+}
+
+function Spinner() {
+  return (
+    <div style={{
+      width: 18, height: 18, borderRadius: '50%',
+      border: `2px solid #313244`, borderTopColor: ACCENT,
+      animation: 'spyde-env-spin 0.8s linear infinite',
+    }} />
+  )
+}

--- a/electron/src/renderer/src/kernel/SpyDEContext.tsx
+++ b/electron/src/renderer/src/kernel/SpyDEContext.tsx
@@ -10,6 +10,7 @@ import React, {
 import { asPlotAppMessage } from './protocol'
 import type { ReportDocState, ReportCell } from './protocol'
 import { WINDOW_DRAG_MIME, FIGURE_DRAG_MIME } from './dnd'
+import { EnvSetupOverlay } from '../components/EnvSetupOverlay'
 
 // Re-export the report doc types so components import them from the kernel
 // context (the single import surface the rest of the renderer already uses).
@@ -185,11 +186,23 @@ interface State {
   loading: { busy: boolean; text: string }   // long file-read busy indicator
   signalTypes: Map<number, { current: string; options: string[] }>   // windowId → signal-type info
   backendExited: { code: number | null; reason?: string } | null   // set when the Python sidecar dies; surfaces a blocking banner
+  envSetup: EnvSetupState | null   // first-run `uv sync` progress; drives the floating setup overlay
   playback: { playing: boolean; speed: number; loop: boolean }   // movie playback clock (session-wide)
   consoleResult: ConsoleResult | null       // last-executed cell (the ConsoleBar echo strip)
   consoleVars: ConsoleVarEntry[]            // live variable table (chips + signal-ref resolution)
   consoleCompletions: { completeId: number; matches: string[] } | null
   consolePreview: ConsolePreviewResult | null   // last live-preview reply (the eye-toggled slot)
+}
+
+// First-run environment setup progress (main-process `env_setup` events, parsed
+// from uv output in envProgress.ts). Drives the floating EnvSetupOverlay.
+export type EnvPhase =
+  | 'resolving' | 'downloading' | 'installing' | 'building' | 'torch' | 'working'
+export interface EnvSetupState {
+  phase: EnvPhase
+  step: string                 // friendly current-step headline
+  percent: number | null       // 0–100 for a download we can measure, else null
+  lines: string[]              // rolling raw uv output tail (bounded)
 }
 
 // Backend `nav_shape_prompt`: confirm the scan grid + step size before opening a
@@ -229,6 +242,9 @@ type Action =
   | { type: 'LOG_BACKFILL'; entries: LogEntry[] }
   | { type: 'LOG_LEVEL'; level: string }
   | { type: 'BACKEND_EXITED'; code: number | null; reason?: string }
+  | { type: 'ENV_SETUP_START' }
+  | { type: 'ENV_SETUP_PROGRESS'; phase?: EnvPhase; step?: string; percent: number | null; raw: string }
+  | { type: 'ENV_SETUP_DONE' }
   | { type: 'PLAYBACK'; playing: boolean; speed: number; loop: boolean }
   | { type: 'CONSOLE_RESULT'; result: ConsoleResult }
   | { type: 'CONSOLE_VARS'; vars: ConsoleVarEntry[] }
@@ -538,9 +554,39 @@ function spydeReducer(state: State, action: Action): State {
       return {
         ...state,
         backendExited: { code: action.code, reason: action.reason },
+        // A setup failure surfaces via BACKEND_EXITED — drop the setup overlay
+        // so the two don't stack.
+        envSetup: null,
         ready: false,
         status: 'Backend stopped',
       }
+
+    case 'ENV_SETUP_START':
+      return {
+        ...state,
+        envSetup: { phase: 'resolving', step: 'Preparing the analysis environment', percent: null, lines: [] },
+        status: 'Setting up the analysis environment…',
+      }
+
+    case 'ENV_SETUP_PROGRESS': {
+      const prev = state.envSetup
+        ?? { phase: 'resolving' as EnvPhase, step: 'Preparing the analysis environment', percent: null, lines: [] }
+      // Keep the last meaningful step/phase when a noisy line parses to nothing;
+      // always append the raw line to the bounded tail so it visibly moves.
+      const lines = [...prev.lines, action.raw].slice(-200)
+      return {
+        ...state,
+        envSetup: {
+          phase: action.phase ?? prev.phase,
+          step: action.step ?? prev.step,
+          percent: action.percent,
+          lines,
+        },
+      }
+    }
+
+    case 'ENV_SETUP_DONE':
+      return { ...state, envSetup: null }
 
     default:
       return state
@@ -621,6 +667,7 @@ export function SpyDEProvider({ children }: { children: React.ReactNode }) {
     loading: { busy: false, text: '' },
     signalTypes: new Map(),
     backendExited: null,
+    envSetup: null,
     playback: { playing: false, speed: 1, loop: false },
     consoleResult: null,
     consoleVars: [],
@@ -753,6 +800,19 @@ export function SpyDEProvider({ children }: { children: React.ReactNode }) {
           // passes a `reason`). Either way, surface the blocking overlay — every
           // sendAction after this no-ops.
           dispatch({ type: 'BACKEND_EXITED', code: msg.code ?? null, reason: msg.reason })
+          break
+
+        case 'env_setup':
+          // First-run `uv sync` progress (index.ts). Drives the floating setup
+          // overlay so a multi-minute download never looks frozen.
+          if (msg.event === 'start') dispatch({ type: 'ENV_SETUP_START' })
+          else if (msg.event === 'done') dispatch({ type: 'ENV_SETUP_DONE' })
+          else dispatch({
+            type: 'ENV_SETUP_PROGRESS',
+            phase: msg.phase, step: msg.step,
+            percent: (typeof msg.percent === 'number' ? msg.percent : null),
+            raw: String(msg.raw ?? ''),
+          })
           break
 
         case 'figure': {
@@ -1397,6 +1457,9 @@ export function SpyDEProvider({ children }: { children: React.ReactNode }) {
       tileWindowsRef, dragKind,
     }}>
       {children}
+      {state.envSetup && !state.backendExited && (
+        <EnvSetupOverlay setup={state.envSetup} />
+      )}
       {state.backendExited && (
         <BackendExitedOverlay
           code={state.backendExited.code}

--- a/electron/src/renderer/src/kernel/protocol.ts
+++ b/electron/src/renderer/src/kernel/protocol.ts
@@ -63,6 +63,19 @@ export interface ProgressMessage extends MsgBase {
   label?: string
 }
 
+/** First-run Python environment setup progress (main process, index.ts). Parsed
+ *  from `uv` output by envProgress.ts. `start`/`done` bracket the setup; each
+ *  `progress` carries a parsed phase/step (+ optional download %) and the raw
+ *  line for the overlay's live tail. Drives the floating EnvSetupOverlay. */
+export interface EnvSetupMessage extends MsgBase {
+  type: 'env_setup'
+  event: 'start' | 'progress' | 'done'
+  phase?: 'resolving' | 'downloading' | 'installing' | 'building' | 'torch' | 'working'
+  step?: string
+  percent?: number | null
+  raw?: string
+}
+
 export interface FigureMessage extends MsgBase {
   type: 'figure'
   window_id: number
@@ -578,6 +591,7 @@ export type PlotAppMessage =
   | StatusMessage
   | ErrorMessage
   | BackendExitedMessage
+  | EnvSetupMessage
   | ProgressMessage
   | FigureMessage
   | ToolbarConfigMessage

--- a/electron/tests/env_setup_overlay.spec.ts
+++ b/electron/tests/env_setup_overlay.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * env_setup_overlay.spec.ts — the floating first-run "Setting up SpyDE" overlay.
+ *
+ * The overlay is normally driven by real `uv sync` output on a packaged first
+ * launch (index.ts → env_setup messages). Here we inject those same messages
+ * via the renderer's _spyde_test_inject hook (no packaged build, no download),
+ * drive it through the phases, and SCREENSHOT each stage so the visual result
+ * is actually inspected (per CLAUDE.md: pixels are the test for UI features).
+ *
+ * Self-contained (Node 23 + Playwright break on cross-file .ts imports).
+ */
+import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test'
+import { join } from 'path'
+import { mkdirSync } from 'fs'
+
+const SHOTS = 'env_setup_shots'
+mkdirSync(SHOTS, { recursive: true })
+
+let app: ElectronApplication
+let page: Page
+
+test.beforeAll(async () => {
+  app = await electron.launch({
+    args: [join(__dirname, '..', 'out', 'main', 'index.js')],
+    env: { ...process.env, SPYDE_NO_DASK: '1' },
+  })
+  page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForSelector('[data-testid="mdi-area"]')
+})
+test.afterAll(async () => { await app?.close() })
+
+async function inject(msg: Record<string, unknown>) {
+  await page.evaluate((m) => { (window as any)._spyde_test_inject?.(m) }, msg)
+}
+
+test('first-run setup overlay: appears, shows phases + step + %, live log, then clears', async () => {
+  const overlay = page.locator('[data-testid="env-setup-overlay"]')
+
+  // Not present before setup starts.
+  await expect(overlay).toHaveCount(0)
+
+  // ── start ──────────────────────────────────────────────────────────────
+  await inject({ type: 'env_setup', event: 'start' })
+  await expect(overlay).toBeVisible()
+  await expect(page.locator('[data-testid="env-setup-step"]')).toBeVisible()
+  await page.screenshot({ path: `${SHOTS}/01-start.png` })
+
+  // ── resolving ──────────────────────────────────────────────────────────
+  await inject({ type: 'env_setup', event: 'progress', phase: 'resolving',
+    step: 'Resolving dependencies', percent: null, raw: 'Resolved 142 packages in 1.2s' })
+  await expect(page.locator('[data-testid="env-setup-step"]'))
+    .toContainText('Resolving dependencies')
+  await expect(page.locator('[data-testid="env-setup-log"]'))
+    .toContainText('Resolved 142 packages')
+
+  // ── downloading torch WITH a percentage (the big, slow step) ─────────────
+  for (const pct of [8, 34, 67, 92]) {
+    await inject({ type: 'env_setup', event: 'progress', phase: 'torch',
+      step: 'Downloading PyTorch', percent: pct,
+      raw: `torch    ====>    ${pct}%  (${pct * 8} MiB/825 MiB)` })
+  }
+  await expect(page.locator('[data-testid="env-setup-step"]')).toContainText('Downloading PyTorch')
+  await expect(page.locator('[data-testid="env-setup-step"]')).toContainText('92%')
+  await page.screenshot({ path: `${SHOTS}/02-torch-download.png` })
+
+  // ── installing ───────────────────────────────────────────────────────────
+  await inject({ type: 'env_setup', event: 'progress', phase: 'installing',
+    step: 'Installing 142 packages', percent: null, raw: 'Installed 142 packages in 800ms' })
+  await expect(page.locator('[data-testid="env-setup-step"]')).toContainText('Installing 142 packages')
+  await page.screenshot({ path: `${SHOTS}/03-installing.png` })
+
+  // Log tail must be visibly growing (newest line present).
+  await expect(page.locator('[data-testid="env-setup-log"]')).toContainText('Installed 142 packages')
+
+  // ── done clears the overlay ──────────────────────────────────────────────
+  await inject({ type: 'env_setup', event: 'done' })
+  await expect(overlay).toHaveCount(0)
+  await page.screenshot({ path: `${SHOTS}/04-cleared.png` })
+})
+
+test('a backend_exited (setup failure) supersedes the setup overlay', async () => {
+  await page.reload()
+  await page.waitForSelector('[data-testid="mdi-area"]')
+  await inject({ type: 'env_setup', event: 'start' })
+  await expect(page.locator('[data-testid="env-setup-overlay"]')).toBeVisible()
+
+  // A packaged setup failure comes through as backend_exited with a reason.
+  await inject({ type: 'backend_exited', code: null, reason: 'Python environment setup failed. …' })
+  await expect(page.locator('[data-testid="env-setup-overlay"]')).toHaveCount(0)
+  await expect(page.locator('[data-testid="backend-exited-overlay"]')).toBeVisible()
+})


### PR DESCRIPTION
## Floating first-run "Setting up SpyDE" overlay with live progress

**Problem:** On first packaged launch, `uv sync` (+ per-machine PyTorch) downloads hundreds of MB over several minutes. The UI showed a single static *"Setting up Python environment…"* line over a blank canvas the entire time — indistinguishable from a hang. (Reported with a screenshot: "It just looks super stuck and I'm not even sure what is happening.")

**Root cause:** `pythonEnv.ts` already streams every `uv` line to `onProgress`, but `index.ts` threw it at the hidden log panel and re-sent the *same static status string* on every line. The real progress existed but was never surfaced.

**Fix:**
- New `envProgress.ts` parses each `uv` line → phase + friendly step + download % (when uv reports one).
- `index.ts` emits structured `env_setup` start/progress/done messages (via the buffered message channel, so it works before the renderer is fully ready).
- New `EnvSetupOverlay` (+ reducer state in `SpyDEContext`) renders a floating card:
  - spinner + "Setting up SpyDE" + a reassurance line (first launch only, ~1–2 GB incl. PyTorch, later launches instant),
  - phase pills (Resolve → Download → PyTorch → Install → Build),
  - the current step + a **real progress bar** when a % is known (indeterminate animated otherwise),
  - a **live scrolling tail** of the raw `uv` output — so it's always visibly moving.

Only appears on a real setup (warm launches emit no `onProgress`, so no flash). A packaged setup **failure** still supersedes it with the existing blocking `backend_exited` overlay.

### Verification
Drove the overlay through every phase via injected `env_setup` messages and screenshotted each stage (`env_setup_overlay.spec.ts`, 2 tests, both green). `parseUvLine` validated against real uv output shapes. Typecheck + `app_log` (shared inject path) green.

Screenshots (torch download @ 92% with real bar + live log; and the indeterminate "Preparing…" start state) attached in the spec's `env_setup_shots/`.
