### PR TITLE
fix(dist): pre-built spyde wheel (fixes read-only egg-info crash on first launch)

### DIFF
--- a/electron/scripts/bundle-python.mjs
+++ b/electron/scripts/bundle-python.mjs
@@ -82,22 +82,33 @@ const PAYLOAD_PYTHON = '3.12'
 writeFileSync(join(outDir, '.python-version'), PAYLOAD_PYTHON + '\n', 'utf8')
 log(`staged .python-version = ${PAYLOAD_PYTHON}`)
 
-// 2. The spyde source package (installed into the venv by uv sync). Exclude the
-//    test suite and caches to keep the payload small.
-cpSync(join(repoRoot, 'spyde'), join(outDir, 'spyde'), {
-  recursive: true,
-  filter: (src) => {
-    // Normalise separators: cpSync hands back backslash paths on Windows, so a
-    // hard-coded "spyde/tests" check would silently fail to exclude the tests.
-    const p = src.replaceAll('\\', '/')
-    return (
-      !p.includes('/spyde/tests') &&
-      !p.includes('__pycache__') &&
-      !p.endsWith('.pyc')
-    )
-  },
+// 2. A PRE-BUILT spyde wheel — NOT the source tree.
+//    Building `spyde` from source on first launch is impossible when the app is
+//    installed read-only (e.g. C:\Program Files): setuptools' build_wheel runs
+//    egg_info, which writes `spyde.egg-info` INTO the source dir → "could not
+//    create 'spyde.egg-info': Access is denied", and `uv sync` exits 1. (This
+//    bit rc.2 AND rc.3; --no-editable does NOT help — a wheel build still writes
+//    egg_info into the tree.) So we build the wheel HERE, where the repo is
+//    writable, and ship the .whl. pythonEnv.ts installs it with
+//    `uv pip install --no-deps` after syncing the deps with --no-install-project,
+//    so NOTHING is built on the user's machine. spyde is pure-Python → one
+//    py3-none-any wheel works on every platform + Python we ship.
+const wheelsDir = join(outDir, 'wheels')
+mkdirSync(wheelsDir, { recursive: true })
+// setuptools_scm can't see a version from the (git-less at build? no — CI has
+// git) tree reliably across environments; pin the already-validated release
+// version so the wheel's metadata matches the tag / package.json.
+const wheelVersion = resolveSpydeVersion()
+const scmEnv = wheelVersion
+  ? { ...process.env, SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPYDE: wheelVersion,
+      SETUPTOOLS_SCM_PRETEND_VERSION: wheelVersion }
+  : process.env
+execSync(`uv build --wheel --out-dir "${wheelsDir}"`, {
+  cwd: repoRoot, stdio: 'inherit', env: scmEnv,
 })
-log('staged spyde/ source')
+const builtWheel = readdirSync(wheelsDir).find((f) => f.endsWith('.whl'))
+if (!builtWheel) throw new Error('uv build produced no spyde wheel')
+log(`staged spyde wheel: ${builtWheel}`)
 
 // 3. The uv binary.
 const vendored = join(__dirname, '..', 'vendor', 'uv', process.platform, uvName)

--- a/electron/src/main/pythonEnv.ts
+++ b/electron/src/main/pythonEnv.ts
@@ -25,7 +25,7 @@
  * root — exactly the previous behaviour.
  */
 import { spawn } from 'child_process'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
 import { createHash } from 'crypto'
 import { join } from 'path'
 
@@ -252,12 +252,50 @@ export function installTorchPerMachine(
   )
 }
 
+/** The pre-built spyde wheel staged by bundle-python.mjs at <projectDir>/wheels/
+ *  (a single py3-none-any .whl). Null in dev (no staged wheel) → the caller
+ *  installs the project from source the old way (dev tree is writable). */
+function stagedSpydeWheel(projectDir: string): string | null {
+  const dir = join(projectDir, 'wheels')
+  if (!existsSync(dir)) return null
+  try {
+    const whl = readdirSync(dir).find((f) => f.startsWith('spyde') && f.endsWith('.whl'))
+    return whl ? join(dir, whl) : null
+  } catch { return null }
+}
+
+/**
+ * Install the PRE-BUILT spyde wheel into the managed env with no dependency
+ * resolution (`--no-deps` — the sync already installed every dependency). This
+ * is the whole reason the wheel exists: it avoids building spyde from the
+ * read-only shipped source tree (setuptools' egg_info write → "Access is
+ * denied", the rc.2/rc.3 first-launch crash). Throws on failure.
+ */
+function installSpydeWheel(
+  projectDir: string,
+  envDir: string,
+  wheel: string,
+  onProgress?: (line: string) => void,
+): Promise<void> {
+  onProgress?.(`[env-setup] installing spyde from wheel ${wheel.split(/[\\/]/).pop()}\n`)
+  return runUv(
+    projectDir, envDir,
+    ['pip', 'install', '--no-deps', '--python', venvPython(envDir), wheel],
+    '', onProgress,
+  )
+}
+
 /**
  * Create/refresh the managed env. On win32/linux (the platforms where the lock
  * pins CUDA torch) this is the two-step per-machine install; on failure — or on
  * macOS, or when the lock has no readable torch pin — the plain full
  * `uv sync --frozen --no-dev` (the original, known-good path) runs instead.
- * Logs which path ran to the progress stream.
+ *
+ * When a pre-built spyde wheel is staged (the packaged app), the syncs use
+ * `--no-install-project` (resolve + install DEPS only, never build spyde) and
+ * spyde is installed from the wheel afterwards — so NOTHING is built from the
+ * read-only source tree. In dev (no staged wheel) the project installs from
+ * source as before. Logs which path ran to the progress stream.
  */
 async function setupEnv(
   projectDir: string,
@@ -265,6 +303,11 @@ async function setupEnv(
   spydeVersion: string,
   onProgress?: (line: string) => void,
 ): Promise<void> {
+  const wheel = stagedSpydeWheel(projectDir)
+  // With a staged wheel, tell uv sync NOT to touch the project (spyde builds
+  // from the read-only tree otherwise); we install the wheel separately.
+  const projectArgs = wheel ? ['--no-install-project'] : ['--no-editable']
+
   const twoStep =
     (process.platform === 'win32' || process.platform === 'linux') &&
     readLockedTorchVersion(projectDir) !== null
@@ -273,20 +316,17 @@ async function setupEnv(
     try {
       onProgress?.('[env-setup] two-step install: uv sync (lock-exact, torch deferred) '
         + 'then torch via --torch-backend=auto\n')
-      // Step 1: everything except torch, exactly as locked. torch is the only
-      // torch-family package in the lock, so one exclusion covers it.
-      // --no-editable: the shipped `spyde` source lives under a READ-ONLY
-      // install dir (e.g. C:\Program Files\SpyDE\resources\python). An editable
-      // install writes `spyde.egg-info` INTO that source tree → "Access is
-      // denied" and the whole sync fails. Non-editable builds the wheel in a
-      // temp dir and installs it into the venv, touching nothing in the bundle.
+      // Step 1: every DEPENDENCY except torch, exactly as locked. torch is the
+      // only torch-family package in the lock, so one exclusion covers it.
       await runUv(
         projectDir, envDir,
-        ['sync', '--frozen', '--no-dev', '--no-editable', '--no-install-package', 'torch'],
+        ['sync', '--frozen', '--no-dev', ...projectArgs, '--no-install-package', 'torch'],
         spydeVersion, onProgress,
       )
       // Step 2: torch resolved for this machine.
       await installTorchPerMachine(projectDir, envDir, onProgress)
+      // Step 3: spyde itself, from the pre-built wheel (packaged only).
+      if (wheel) await installSpydeWheel(projectDir, envDir, wheel, onProgress)
       onProgress?.('[env-setup] per-machine torch install complete\n')
       return
     } catch (err) {
@@ -297,7 +337,6 @@ async function setupEnv(
   }
 
   onProgress?.('[env-setup] running full locked uv sync\n')
-  // --no-editable: see the two-step branch — never write egg-info into the
-  // read-only shipped source tree.
-  await runUv(projectDir, envDir, ['sync', '--frozen', '--no-dev', '--no-editable'], spydeVersion, onProgress)
+  await runUv(projectDir, envDir, ['sync', '--frozen', '--no-dev', ...projectArgs], spydeVersion, onProgress)
+  if (wheel) await installSpydeWheel(projectDir, envDir, wheel, onProgress)
 }


### PR DESCRIPTION
## Ship a pre-built spyde wheel — never build from the read-only install tree

**rc.2 and rc.3 both crashed on first launch** with:
```
× Failed to build `spyde @ file:///C:/Program Files/SpyDE/resources/python`
  error: could not create 'spyde.egg-info': Access is denied
```

### Root cause (why `--no-editable` didn't fix it)
setuptools' `build_wheel` runs `egg_info`, which writes `spyde.egg-info` **into the source directory**. The app installs **read-only** (`C:\Program Files`), so **any** build from that tree — editable *or* wheel — fails. `--no-editable` (my rc.3 attempt) still builds a wheel *from the source*, so it kept failing. My earlier local test passed only because the dev tree is writable.

### Fix: don't build spyde on the user's machine at all
- **`bundle-python.mjs`** now builds a spyde wheel at bundle time (CI, writable tree) via `uv build --wheel` and stages `wheels/spyde-<ver>-py3-none-any.whl` **instead of the source tree**. spyde is pure-Python → one cross-platform wheel.
- **`pythonEnv.ts`** syncs dependencies with `--no-install-project` (never touches the project) and installs spyde from the wheel with `uv pip install --no-deps`. Dev (no staged wheel, writable tree) falls back to the old source install.

### Verified end-to-end
Against the **actual staged payload made read-only**: sync installs deps + clones hyperspy with **no spyde build** (no `egg_info`, no "Access is denied"), the wheel installs in ~200ms, `import spyde` resolves from the env, and the payload has **no source tree** for setuptools to write into.

> The git `failed to unlink` seen during testing was a **MAX_PATH artifact** of a pathologically deep scratch cache path, not a real bug — a normal-length cache path (`%APPDATA%\spyde-electron\uv-cache`) clones cleanly. This also explains the intermittent `unlink` errors seen earlier in the session.

### Combines with the earlier install fixes (all on main)
1. no-git → vendored MinGit ✓
2. **read-only build → this PR (pre-built wheel)** ✓
3. Python 3.14 → py3.12 pin ✓

Next: cut **v0.2.0-rc.4** after this merges and re-test on the clean machine.
