### PR TITLE
Presentation editing fixes: figure slide, split layouts, presenter exit

### DIFF
--- a/electron/src/renderer/src/components/PresentMode.tsx
+++ b/electron/src/renderer/src/components/PresentMode.tsx
@@ -310,6 +310,8 @@ export function PresentMode({ initialSlide, onSlideChange, onExit, onLaunchLive 
           index={index}
           count={count}
           onGo={go}
+          onExitPresenter={() => setPresenter(false)}
+          onExit={onExit}
         />
       )}
 
@@ -403,11 +405,13 @@ export function PresentMode({ initialSlide, onSlideChange, onExit, onLaunchLive 
  *  we never duplicate the live audience iframes; the live embeds stay in the hidden
  *  audience stack. Advancing (arrows / the header nav) drives the SAME `index`, so
  *  audience + presenter stay in sync. */
-function PresenterView({ slides, index, count, onGo }: {
+function PresenterView({ slides, index, count, onGo, onExitPresenter, onExit }: {
   slides: ReportCell[][]
   index: number
   count: number
   onGo: (n: number) => void
+  onExitPresenter: () => void   // back to the clean audience slide (leave presenter)
+  onExit: () => void            // exit Present mode entirely
 }) {
   const current = slides[index] ?? []
   const next = index + 1 < count ? slides[index + 1] : null
@@ -482,6 +486,20 @@ function PresenterView({ slides, index, count, onGo }: {
             title="Next (→ / Space)"
             onClick={() => onGo(index + 1)}
           >›</button>
+          {/* Explicit exits — the presenter dashboard covers the top-right
+              controls, so these are the only on-screen way out. */}
+          <button
+            data-testid="presenter-exit-view"
+            style={styles.presExitBtn}
+            title="Leave presenter view — show the clean audience slide (S)"
+            onClick={onExitPresenter}
+          >Audience view</button>
+          <button
+            data-testid="presenter-exit-present"
+            style={styles.presExitBtnStrong}
+            title="Exit the presentation (Esc)"
+            onClick={onExit}
+          >✕ Exit</button>
         </div>
       </div>
 
@@ -912,6 +930,14 @@ const styles: Record<string, React.CSSProperties> = {
     width: 40, height: 40, fontSize: 24, lineHeight: 1, cursor: 'pointer',
   },
   presCounter: { fontSize: 18, color: '#cdd6f4', minWidth: 66, textAlign: 'center', fontWeight: 600 },
+  presExitBtn: {
+    background: 'rgba(30,30,46,0.9)', color: '#cdd6f4', border: '1px solid #313244',
+    borderRadius: 8, padding: '0 14px', height: 40, fontSize: 14, cursor: 'pointer',
+  },
+  presExitBtnStrong: {
+    background: '#f38ba8', color: '#11111b', border: 'none',
+    borderRadius: 8, padding: '0 16px', height: 40, fontSize: 14, fontWeight: 700, cursor: 'pointer',
+  },
   presPreviews: {
     display: 'grid', gridTemplateColumns: '1.6fr 1fr', gap: '2vw',
     flex: '0 0 48%', minHeight: 0,

--- a/electron/src/renderer/src/components/ReportFigureCell.tsx
+++ b/electron/src/renderer/src/components/ReportFigureCell.tsx
@@ -1194,6 +1194,130 @@ function AnnotationStyleLine({ color, onColor, testidBase, colorTestid,
   )
 }
 
+// ── Shared figure-editing overlay (used by BOTH figure cells AND split cells) ──
+/**
+ * FigureEditOverlay — the figure-editing UI for a live figure cell OR a split
+ * cell's figure side: the floating AnnotationPopover + TextSizePopover (opened by
+ * clicking an annotation / double-clicking a text element on the live figure) and
+ * the slim FigureEditPanel edit bar (add annotation / layers / layout). It owns the
+ * popover + selected-panel state and the spyde:figure_event / report_panel_selected
+ * subscriptions, keyed by the cell's fig_id — so a split cell gets the SAME
+ * annotation-editing pop-down a figure cell does (it was previously missing on
+ * splits, so editing a split's figure showed no annotation tools).
+ *
+ * ``figId`` is the cell's current live figure id (from reportFigures). ``editOpen``
+ * gates the annotation popover + the edit bar (the text-size popover works even out
+ * of edit mode). ``onCloseEdit`` turns edit mode off.
+ */
+export function FigureEditOverlay({ cell, isLive, editOpen, figId, sendAction, onCloseEdit }: {
+  cell: ReportCell
+  isLive: boolean
+  editOpen: boolean
+  figId: string | null
+  sendAction: (action: string, payload?: Record<string, unknown>, windowId?: number) => void
+  onCloseEdit: () => void
+}) {
+  const [selectedPanel, setSelectedPanel] = React.useState<string | null>(null)
+  const [popover, setPopover] = React.useState<PopoverTarget | null>(null)
+
+  // Mirror the backend's panel selection for THIS cell while editing.
+  React.useEffect(() => {
+    if (!editOpen) { setSelectedPanel(null); return }
+    const onSelected = (ev: Event) => {
+      const d = (ev as CustomEvent).detail as { cell_id?: string; panel_id?: string | null }
+      if (d?.cell_id !== cell.id) return
+      setSelectedPanel(d.panel_id ?? null)
+    }
+    window.addEventListener('spyde:report_panel_selected', onSelected)
+    return () => window.removeEventListener('spyde:report_panel_selected', onSelected)
+  }, [editOpen, cell.id])
+
+  // The figure-event listener reads the CURRENT figId/cell via refs (a rebuild
+  // mints a new figId; report_state replaces the cell each edit).
+  const figIdRef = React.useRef<string | null>(null)
+  figIdRef.current = figId
+  const cellRef = React.useRef(cell)
+  cellRef.current = cell
+
+  React.useEffect(() => {
+    if (!editOpen) setPopover(p => (p?.kind === 'annotation' ? null : p))
+    const onFigEvent = (ev: Event) => {
+      const d = (ev as CustomEvent).detail as
+        { figId?: string; event?: Record<string, unknown> } | undefined
+      if (!d?.event || d.figId !== figIdRef.current) return
+      const e = d.event
+      const widgetId = typeof e.widget_id === 'string' ? e.widget_id : null
+      const c = cellRef.current
+      if (e.event_type === 'double_click') {
+        if (typeof e.target !== 'string') return
+        setPopover({
+          kind: 'text_size',
+          panelId: typeof e.panel_id === 'string' ? e.panel_id : null,
+          target: e.target as TextSizeTarget,
+          fx: typeof e.x === 'number' ? e.x : 0.5,
+          fy: typeof e.y === 'number' ? e.y : 0.5,
+        })
+        return
+      }
+      if (!editOpen) return
+      if (e.event_type === 'pointer_up') {
+        const hit = widgetId != null ? c.ann_widgets?.[widgetId] : undefined
+        if (hit) {
+          const { fx, fy } = panelAnnAnchor(c.figure, hit.panel_id, hit.index)
+          setPopover({ kind: 'annotation', scope: 'panel', panelId: hit.panel_id, index: hit.index, fx, fy })
+          return
+        }
+        if (widgetId == null && e.figure_marker && e.marker_id != null) {
+          const anns = c.figure?.annotations ?? []
+          const idx = anns.findIndex(a => a.id === e.marker_id)
+          if (idx >= 0) {
+            setPopover({
+              kind: 'annotation', scope: 'figure', panelId: null, index: idx,
+              fx: typeof e.x === 'number' ? e.x : 0.5,
+              fy: typeof e.y === 'number' ? e.y : 0.5,
+            })
+          }
+          return
+        }
+        return
+      }
+      if (e.event_type === 'pointer_down' && widgetId == null &&
+          (e.figure_background || e.img_x != null)) {
+        setPopover(p => (p?.kind === 'annotation' ? null : p))
+      }
+    }
+    const onKey = (ke: KeyboardEvent) => { if (ke.key === 'Escape') setPopover(null) }
+    window.addEventListener('spyde:figure_event', onFigEvent)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('spyde:figure_event', onFigEvent)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [editOpen, cell.id])
+
+  if (!isLive || !cell.figure) return null
+  const aspect = String(figureAspectRatio(cell.figure))
+  return (
+    <>
+      {editOpen && popover?.kind === 'annotation' && (
+        <div style={{ ...styles.popoverLayer, aspectRatio: aspect }}>
+          <AnnotationPopover cell={cell} popover={popover}
+            onClose={() => setPopover(null)} sendAction={sendAction} />
+        </div>
+      )}
+      {popover?.kind === 'text_size' && (
+        <div style={{ ...styles.popoverLayer, aspectRatio: aspect }}>
+          <TextSizePopover cell={cell} popover={popover}
+            onClose={() => setPopover(null)} sendAction={sendAction} />
+        </div>
+      )}
+      {editOpen && (
+        <FigureEditPanel cell={cell} selectedPanel={selectedPanel} onClose={onCloseEdit} />
+      )}
+    </>
+  )
+}
+
 // ── Slim edit bar ─────────────────────────────────────────────────────────────
 // One compact bar under the figure (edit mode only). Annotation STYLE editing
 // lives in the floating AnnotationPopover (click the annotation on the live

--- a/electron/src/renderer/src/components/ReportSidebar.tsx
+++ b/electron/src/renderer/src/components/ReportSidebar.tsx
@@ -523,6 +523,12 @@ export function ReportSidebar() {
       slide_kind: 'title',
     })
   }
+  // A figure slide: an empty placeholder figure cell (a dashed drop-zone) as its
+  // own slide. Dropping a window onto it makes it a live figure.
+  const addFigureSlide = () => {
+    setAddSlideMenu(false)
+    sendAction('report_add_figure_placeholder', { slide_break: true })
+  }
 
   // ── Per-slide header verbs (addressed to the slide's FIRST cell) ──────────────
   const toggleSlideTitle = (firstCellId: string) =>
@@ -1196,10 +1202,10 @@ export function ReportSidebar() {
               >+ Add slide ▾</button>
               {addSlideMenu && (
                 <div style={styles.addSlideMenu} data-testid="report-add-slide-menu" role="menu">
-                  <MenuItem testid="add-slide-text" label="Text slide" onClick={addTextSlide} />
-                  <MenuItem testid="add-slide-split" label="Split slide (text + figure)"
-                    onClick={addSplitSlide} />
-                  <MenuItem testid="add-slide-title" label="Title slide" onClick={addTitleSlide} />
+                  <MenuItem testid="add-slide-text" label="Add text slide" onClick={addTextSlide} />
+                  <MenuItem testid="add-slide-split" label="Add split slide" onClick={addSplitSlide} />
+                  <MenuItem testid="add-slide-title" label="Add title slide" onClick={addTitleSlide} />
+                  <MenuItem testid="add-slide-figure" label="Add figure slide" onClick={addFigureSlide} />
                 </div>
               )}
             </div>

--- a/electron/src/renderer/src/components/ReportSplitCell.tsx
+++ b/electron/src/renderer/src/components/ReportSplitCell.tsx
@@ -31,7 +31,7 @@ import { reportClipboard } from '../kernel/reportClipboard'
 import type { ReportCell } from '../kernel/protocol'
 import { FIGURE_DRAG_MIME, WINDOW_DRAG_MIME } from '../kernel/dnd'
 import { CellChrome } from './CellChrome'
-import { SeamlessFigureFrame } from './ReportFigureCell'
+import { SeamlessFigureFrame, FigureEditOverlay } from './ReportFigureCell'
 
 const DROP_MIMES = [FIGURE_DRAG_MIME, WINDOW_DRAG_MIME]
 const isComposeDrag = (dt: DataTransfer) => DROP_MIMES.some(m => dt.types.includes(m))
@@ -296,10 +296,13 @@ export function ReportSplitCell({ cell, onRemove, index, dragProps, reorderActiv
         ...(dragProps.dropBefore ? styles.cellDropBefore : {}),
       }}
     >
-      {hover && (
+      {/* The editing chrome is ALWAYS visible (not hover-gated) — a split slide's
+          tools were undiscoverable when they only appeared on hover. Hover just
+          brightens it. */}
+      {(
         <CellChrome
           cellId={cell.id}
-          styles={{ chrome: styles.chrome, chromeBtn: styles.chromeBtn }}
+          styles={{ chrome: { ...styles.chrome, ...(hover ? styles.chromeHover : {}) }, chromeBtn: styles.chromeBtn }}
           onCopy={doCopy}
           onDuplicate={doDuplicate}
           onDelete={onRemove}
@@ -375,6 +378,22 @@ export function ReportSplitCell({ cell, onRemove, index, dragProps, reorderActiv
         gridTemplateRows: stacked ? 'auto auto' : '1fr' }}>
         {textFirst ? <>{textPane}{figurePane}</> : <>{figurePane}{textPane}</>}
       </div>
+
+      {/* The SAME figure-editing pop-down a figure cell gets — the annotation
+          style popover + text-size popover + the add-annotation edit bar — for the
+          split's figure side. Without this, toggling Edit on a split's figure
+          entered edit mode on the backend but showed NO annotation tools. */}
+      <FigureEditOverlay
+        cell={cell}
+        isLive={isLive}
+        editOpen={figEditOpen}
+        figId={fig?.figId ?? null}
+        sendAction={sendAction}
+        onCloseEdit={() => {
+          setFigEditOpen(false)
+          sendAction('repfig_set_edit_mode', { cell_id: cell.id, editing: false })
+        }}
+      />
     </div>
   )
 }
@@ -408,11 +427,15 @@ const styles: Record<string, React.CSSProperties> = {
   layoutMenuItemActive: { background: '#313244' },
   layoutGlyph: { fontSize: 15, width: 18, textAlign: 'center' },
   chrome: {
-    position: 'absolute', top: 6, right: 6, zIndex: 4,
+    position: 'absolute', top: 6, right: 6, zIndex: 6,
     display: 'flex', alignItems: 'center', gap: 2,
     background: 'rgba(24,24,37,0.96)', borderRadius: 8, padding: 3,
     border: '1px solid #313244', boxShadow: '0 3px 10px rgba(0,0,0,0.35)',
+    // Always visible (not hover-gated) but slightly dimmed until hovered so the
+    // tools are discoverable without covering the figure side too loudly.
+    opacity: 0.78, transition: 'opacity 120ms ease',
   },
+  chromeHover: { opacity: 1 },
   chromeBtn: {
     background: 'none', border: 'none', color: '#cdd6f4', cursor: 'pointer',
     fontSize: 15, lineHeight: 1, borderRadius: 6,

--- a/electron/src/renderer/src/components/ReportSplitCell.tsx
+++ b/electron/src/renderer/src/components/ReportSplitCell.tsx
@@ -88,7 +88,13 @@ export function ReportSplitCell({ cell, onRemove, index, dragProps, reorderActiv
   const taRef = useRef<HTMLTextAreaElement>(null)
   const rootRef = useRef<HTMLDivElement>(null)
 
-  const layout = cell.split_layout === 'text-right' ? 'text-right' : 'text-left'
+  const LAYOUTS = ['text-left', 'text-right', 'text-top', 'text-bottom'] as const
+  type Layout = typeof LAYOUTS[number]
+  const layout: Layout = (LAYOUTS as readonly string[]).includes(cell.split_layout ?? '')
+    ? (cell.split_layout as Layout) : 'text-left'
+  const stacked = layout === 'text-top' || layout === 'text-bottom'
+  const textFirst = layout === 'text-left' || layout === 'text-top'
+  const [layoutMenu, setLayoutMenu] = useState(false)
   const empty = !!cell.split_empty
   // The figure side rides in the same fig_id/reportFigures plumbing as a figure
   // cell (keyed by the CELL id). A photo side ships `image` instead of a spec.
@@ -135,11 +141,17 @@ export function ReportSplitCell({ cell, onRemove, index, dragProps, reorderActiv
   const rendered = React.useMemo(() => renderMarkdown(cell.source ?? ''), [cell.source])
   const textEmpty = !(cell.source ?? '').trim()
 
-  // ── Layout switch (swap text ↔ figure sides) ──────────────────────────────
-  const swapLayout = () =>
-    sendAction('report_set_split_layout', {
-      cell_id: cell.id, layout: layout === 'text-left' ? 'text-right' : 'text-left',
-    })
+  // ── Layout switch (a dropdown picker: 4 arrangements) ─────────────────────
+  const setLayout = (l: Layout) => {
+    setLayoutMenu(false)
+    sendAction('report_set_split_layout', { cell_id: cell.id, layout: l })
+  }
+  const LAYOUT_OPTS: { value: Layout; label: string; glyph: string }[] = [
+    { value: 'text-left', label: 'Text left', glyph: '◧' },
+    { value: 'text-right', label: 'Text right', glyph: '◨' },
+    { value: 'text-top', label: 'Text top', glyph: '⬒' },
+    { value: 'text-bottom', label: 'Text bottom', glyph: '⬓' },
+  ]
 
   // ── Figure-side drop (fill the empty figure side in place) ─────────────────
   const onFigDragOver = (e: React.DragEvent) => {
@@ -326,24 +338,42 @@ export function ReportSplitCell({ cell, onRemove, index, dragProps, reorderActiv
                   onClick={refreshFigure}
                 >⟳</button>
               )}
-              <button
-                data-testid={`report-split-layout-${cell.id}`}
-                style={styles.chromeBtn}
-                title={layout === 'text-left'
-                  ? 'Text is on the LEFT — click to move it to the right'
-                  : 'Text is on the RIGHT — click to move it to the left'}
-                onClick={swapLayout}
-              >{layout === 'text-left' ? '◨' : '◧'}</button>
+              <div style={{ position: 'relative' }}>
+                <button
+                  data-testid={`report-split-layout-${cell.id}`}
+                  style={styles.chromeBtn}
+                  title="Split layout (text vs figure arrangement)"
+                  aria-haspopup="menu"
+                  aria-expanded={layoutMenu}
+                  onClick={() => setLayoutMenu(v => !v)}
+                >{LAYOUT_OPTS.find(o => o.value === layout)?.glyph ?? '◧'} ▾</button>
+                {layoutMenu && (
+                  <div style={styles.layoutMenu} role="menu"
+                    data-testid={`report-split-layout-menu-${cell.id}`}>
+                    {LAYOUT_OPTS.map(o => (
+                      <button key={o.value} role="menuitemradio"
+                        aria-checked={layout === o.value}
+                        data-testid={`report-split-layout-${cell.id}-${o.value}`}
+                        style={{ ...styles.layoutMenuItem, ...(layout === o.value ? styles.layoutMenuItemActive : {}) }}
+                        onClick={() => setLayout(o.value)}>
+                        <span style={styles.layoutGlyph}>{o.glyph}</span> {o.label}
+                        {layout === o.value && <span style={{ marginLeft: 'auto' }}>✓</span>}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </>
           }
         />
       )}
 
-      {/* The two panes, ordered by split_layout. */}
-      <div style={styles.panes}>
-        {layout === 'text-left'
-          ? <>{textPane}{figurePane}</>
-          : <>{figurePane}{textPane}</>}
+      {/* The two panes, ordered + oriented by split_layout (side-by-side or
+          stacked; text first or figure first). */}
+      <div style={{ ...styles.panes,
+        gridTemplateColumns: stacked ? '1fr' : '1fr 1fr',
+        gridTemplateRows: stacked ? 'auto auto' : '1fr' }}>
+        {textFirst ? <>{textPane}{figurePane}</> : <>{figurePane}{textPane}</>}
       </div>
     </div>
   )
@@ -364,6 +394,19 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, alignItems: 'stretch',
   },
   pane: { minWidth: 0, display: 'flex', flexDirection: 'column' },
+  layoutMenu: {
+    position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 20,
+    background: '#1e1e2e', border: '1px solid #313244', borderRadius: 6,
+    padding: 4, minWidth: 130, boxShadow: '0 6px 18px rgba(0,0,0,0.5)',
+    display: 'flex', flexDirection: 'column', gap: 2,
+  },
+  layoutMenuItem: {
+    display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+    background: 'none', border: 'none', color: '#cdd6f4', cursor: 'pointer',
+    fontSize: 12, padding: '5px 8px', borderRadius: 4, textAlign: 'left',
+  },
+  layoutMenuItemActive: { background: '#313244' },
+  layoutGlyph: { fontSize: 15, width: 18, textAlign: 'center' },
   chrome: {
     position: 'absolute', top: 6, right: 6, zIndex: 4,
     display: 'flex', alignItems: 'center', gap: 2,

--- a/electron/tests/presentation_editing.spec.ts
+++ b/electron/tests/presentation_editing.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * presentation_editing.spec.ts — presentation authoring fixes, end-to-end.
+ *
+ * Drives the real app to verify:
+ *   1) The "+ Add slide" menu offers FOUR options — Add text / split / title /
+ *      figure slide — and "Add figure slide" creates a placeholder figure cell as
+ *      its own slide.
+ *   2) A split slide is fully EDITABLE in a presentation: text edits persist, and
+ *      the layout dropdown offers the four arrangements (left/right/top/bottom),
+ *      persisting the choice.
+ *   3) Present mode → presenter view has an explicit EXIT (back to audience + out
+ *      of Present) — the presenter dashboard no longer traps the user.
+ */
+import { test, expect } from '@playwright/test'
+import { join } from 'path'
+import { mkdirSync } from 'fs'
+const { launchApp, backendErrorLines } = require('./_harness.cjs')
+
+const SHOTS = join(__dirname, '..', 'presentation_editing_shots')
+
+async function reportDoc(page: any): Promise<any> {
+  return await page.evaluate(() => (window as any)._spyde_test_report?.())
+}
+
+let ctx: Awaited<ReturnType<typeof launchApp>>
+
+test.describe.configure({ mode: 'serial' })
+test.setTimeout(180_000)
+
+test.beforeAll(async () => {
+  mkdirSync(SHOTS, { recursive: true })
+  ctx = await launchApp({ dask: false })
+  const { page } = ctx
+  await page.waitForTimeout(1200)
+  const tour = page.getByTestId('tour-close')
+  if (await tour.count()) await tour.click().catch(() => {})
+  await page.getByTestId('toggle-report').click()
+  await page.getByTestId('report-new-presentation-card').click()
+  await expect(page.getByTestId('report-type-badge')).toHaveText('Presentation')
+})
+
+test.afterAll(async () => {
+  try { ctx?.assertNoJsErrors() } finally { await ctx?.app?.close() }
+})
+
+test('1) Add-slide menu has 4 options incl. figure; Add figure slide → placeholder', async () => {
+  const { page } = ctx
+  await page.getByTestId('report-add-slide').click()
+  await expect(page.getByTestId('report-add-slide-menu')).toBeVisible()
+  for (const t of ['add-slide-text', 'add-slide-split', 'add-slide-title', 'add-slide-figure']) {
+    await expect(page.getByTestId(t), `${t} missing`).toBeVisible()
+  }
+  await page.screenshot({ path: join(SHOTS, '01-add-slide-menu.png') })
+  await page.getByTestId('add-slide-figure').click()
+  await page.waitForTimeout(400)
+  const doc = await reportDoc(page)
+  const fig = doc?.cells?.find((c: any) => c.cell_type === 'figure' && c.placeholder)
+  expect(fig, 'no placeholder figure slide created').toBeTruthy()
+  expect(fig.slide_break).toBe(true)
+  ctx.assertNoJsErrors()
+})
+
+test('2) split slide is editable — text persists, layout dropdown has 4 arrangements', async () => {
+  const { page } = ctx
+  await page.getByTestId('report-add-slide').click()
+  await page.getByTestId('add-slide-split').click()
+  await page.waitForTimeout(400)
+  const doc = await reportDoc(page)
+  const split = doc.cells.find((c: any) => c.cell_type === 'split')
+  expect(split).toBeTruthy()
+  const id = split.id
+
+  // Text edit persists.
+  await page.getByTestId(`report-split-rendered-${id}`).dblclick()
+  const ta = page.locator(`[data-testid="report-splitcell-${id}"] textarea`)
+  await expect(ta).toBeVisible()
+  await ta.fill('Slide body text')
+  await ta.blur()
+  await page.waitForTimeout(400)
+  expect((await reportDoc(page)).cells.find((c: any) => c.id === id).source).toBe('Slide body text')
+
+  // Layout dropdown → 4 arrangements; pick "text-top" (stacked) and confirm persist.
+  await page.getByTestId(`report-splitcell-${id}`).hover()
+  await page.getByTestId(`report-split-layout-${id}`).click()
+  const menu = page.getByTestId(`report-split-layout-menu-${id}`)
+  await expect(menu).toBeVisible()
+  for (const l of ['text-left', 'text-right', 'text-top', 'text-bottom']) {
+    await expect(page.getByTestId(`report-split-layout-${id}-${l}`), `layout ${l} missing`).toBeVisible()
+  }
+  await page.screenshot({ path: join(SHOTS, '02-split-layout-menu.png') })
+  await page.getByTestId(`report-split-layout-${id}-text-top`).click()
+  await page.waitForTimeout(300)
+  expect((await reportDoc(page)).cells.find((c: any) => c.id === id).split_layout).toBe('text-top')
+  ctx.assertNoJsErrors()
+})
+
+test('3) presenter view has an explicit exit', async () => {
+  const { page } = ctx
+  // Enter Present mode.
+  await page.getByTestId('report-present').click()
+  await expect(page.getByTestId('present-mode')).toBeVisible({ timeout: 10_000 })
+  // Toggle presenter view (S).
+  await page.keyboard.press('s')
+  await expect(page.getByTestId('presenter-view')).toBeVisible({ timeout: 5_000 })
+  // The exit controls are present + clickable (not covered).
+  await expect(page.getByTestId('presenter-exit-view')).toBeVisible()
+  const exitPresent = page.getByTestId('presenter-exit-present')
+  await expect(exitPresent).toBeVisible()
+  await page.screenshot({ path: join(SHOTS, '03-presenter-exit.png') })
+  // "Audience view" leaves presenter view but stays in Present.
+  await page.getByTestId('presenter-exit-view').click()
+  await expect(page.getByTestId('presenter-view')).toBeHidden({ timeout: 5_000 })
+  await expect(page.getByTestId('present-mode')).toBeVisible()
+  // Re-enter presenter and exit Present entirely.
+  await page.keyboard.press('s')
+  await expect(page.getByTestId('presenter-view')).toBeVisible({ timeout: 5_000 })
+  await page.getByTestId('presenter-exit-present').click()
+  await expect(page.getByTestId('present-mode')).toBeHidden({ timeout: 5_000 })
+  ctx.assertNoJsErrors()
+})
+
+test('4) no backend tracebacks', async () => {
+  const errs = backendErrorLines(ctx.backend)
+  if (errs.length) console.log('[pres] backend errors:\n' + errs.join('\n'))
+  expect(errs).toEqual([])
+})

--- a/electron/tests/presentation_fixes.spec.ts
+++ b/electron/tests/presentation_fixes.spec.ts
@@ -120,6 +120,64 @@ test('B1: a split cell shows text AND figure on a slide (Present mode)', async (
   }
 })
 
+test('B1b: editing a split cell\'s figure side shows the annotation pop-down', async () => {
+  const { mkdirSync } = require('fs')
+  mkdirSync(SHOTS, { recursive: true })
+  const ctx = await launchApp({ dask: true })
+  const { page } = ctx
+  try {
+    await page.waitForTimeout(1500)
+    await backendAction(page, 'load_test_data_si_grains')
+    await waitForSubwindowCount(page, 2, 60_000)
+    await page.waitForTimeout(1500)
+    await openReportSidebar(page)
+
+    await backendAction(page, 'report_new', { type: 'presentation' })
+    await expect(page.getByTestId('report-type-badge')).toHaveText('Presentation')
+
+    // A split slide with its figure side filled from the live signal window.
+    await backendAction(page, 'report_add_split_cell', {
+      source: '## Edit me\nfigure side has annotation tools', layout: 'text-left',
+    })
+    await expect.poll(async () => {
+      const doc = await reportDoc(page)
+      return (doc?.cells ?? []).some((x: any) => x.cell_type === 'split')
+    }, { timeout: 15_000 }).toBe(true)
+    const cellId = (await reportDoc(page)).cells.find((x: any) => x.cell_type === 'split').id
+
+    const sigId = await windowIdFromPill(page,
+      '[data-testid="subwindow"] [data-testid="window-breadcrumb"]')
+    expect(Number.isFinite(sigId)).toBe(true)
+    await backendAction(page, 'report_add_figure', { source_window_id: sigId, at_cell: cellId })
+    await expect.poll(async () => {
+      const c = (await reportDoc(page))?.cells?.find((x: any) => x.id === cellId)
+      return c && c.cell_type === 'split' && !!c.figure
+    }, { timeout: 30_000 }).toBe(true)
+
+    // BEFORE edit: no annotation edit panel.
+    const editPanel = page.getByTestId(`figcell-edit-${cellId}`)
+    await expect(editPanel).toHaveCount(0)
+    await page.screenshot({ path: join(SHOTS, '03-split-before-edit.png') })
+
+    // Toggle the split's figure-edit (the ✎ chrome button). The edit pop-down
+    // (add annotation / callouts / layers) must appear — this was the bug: the
+    // split cell entered edit mode on the backend but rendered NO tools.
+    await page.getByTestId(`report-splitcell-${cellId}`).hover()
+    await page.getByTestId(`report-split-edit-${cellId}`).click()
+    await expect(editPanel).toBeVisible({ timeout: 10_000 })
+    await page.screenshot({ path: join(SHOTS, '04-split-edit-tools.png') })
+
+    // The add-annotation palette is present inside the edit bar (the "+ Text"
+    // button is the annotation entry point — proves the pop-down is real, not
+    // just an empty container).
+    await expect(editPanel.getByRole('button', { name: '+ Text' })).toBeVisible()
+
+    ctx.assertNoJsErrors()
+  } finally {
+    await ctx.app.close()
+  }
+})
+
 test('B2: a figure cell on a presentation slide accepts a combine drop', async () => {
   const { mkdirSync } = require('fs')
   mkdirSync(SHOTS, { recursive: true })

--- a/electron/tests/report_redesign.spec.ts
+++ b/electron/tests/report_redesign.spec.ts
@@ -198,9 +198,12 @@ test('c) + Add split block → drop zone → fill figure beside text → swap si
   await page.waitForTimeout(1500)   // let the figure paint
   await page.screenshot({ path: join(SHOTS, '06-split-filled-text-left.png') })
 
-  // The layout switch swaps text ↔ figure sides.
+  // The layout control is a dropdown (text-left/right/top/bottom); open it and
+  // pick "text-right" to move the text to the right (figure swaps to the left).
   await split.dispatchEvent('mouseover', { bubbles: true })
   await page.getByTestId(`report-split-layout-${cellId}`).click()
+  await expect(page.getByTestId(`report-split-layout-menu-${cellId}`)).toBeVisible()
+  await page.getByTestId(`report-split-layout-${cellId}-text-right`).click()
   await expect.poll(async () => {
     const doc = await reportDoc(page)
     const c = (doc?.cells ?? []).find((x: any) => x.id === cellId)

--- a/spyde/actions/registry.py
+++ b/spyde/actions/registry.py
@@ -99,6 +99,7 @@ STAGED_HANDLERS: dict[str, str] = {
     # Report/Presentation redesign Wave A — the split-block primitive (text side
     # BESIDE a figure/photo side, one atomic cell).
     "report_add_split_cell":   "spyde.actions.report.handlers.report_add_split_cell",
+    "report_add_figure_placeholder": "spyde.actions.report.handlers.report_add_figure_placeholder",
     "report_set_split_layout": "spyde.actions.report.handlers.report_set_split_layout",
     "report_set_split_figure": "spyde.actions.report.handlers.report_set_split_figure",
     "report_update_cell":      "spyde.actions.report.handlers.report_update_cell",

--- a/spyde/actions/report/export_html.py
+++ b/spyde/actions/report/export_html.py
@@ -98,6 +98,8 @@ figure.report-figure figcaption { margin-top: 0.6rem; font-size: 0.9rem;
    column. */
 .report-article .split-block { display: grid; grid-template-columns: 1fr 1fr;
   gap: 1.5rem; align-items: center; margin: 1.75rem 0; }
+.report-article .split-block--stacked { grid-template-columns: 1fr;
+  grid-auto-rows: auto; }
 .report-article .split-col { min-width: 0; }
 .report-article .split-fig figure.report-figure { margin: 0; }
 @media (max-width: 720px) {
@@ -287,9 +289,13 @@ def _split_cell_html(mgr, cell: Cell, assets: dict, *, interactive: bool,
     layout = _normalize_split_layout(cell.split_layout)
     text_col = f"<div class=\"split-col split-text\">\n{text_html}\n</div>"
     fig_col = f"<div class=\"split-col split-fig\">\n{fig_html}\n</div>"
-    first, second = ((text_col, fig_col) if layout == "text-left"
-                     else (fig_col, text_col))
-    return f"<div class=\"split-block\">\n{first}\n{second}\n</div>"
+    # Text-first for left/top; figure-first for right/bottom. A "--stacked"
+    # modifier switches the block from 2 columns to 2 rows (CSS below).
+    text_first = layout in ("text-left", "text-top")
+    stacked = layout in ("text-top", "text-bottom")
+    first, second = (text_col, fig_col) if text_first else (fig_col, text_col)
+    cls = "split-block split-block--stacked" if stacked else "split-block"
+    return f"<div class=\"{cls}\">\n{first}\n{second}\n</div>"
 
 
 def _render_cell_html(mgr, cell: Cell, assets: dict, *, interactive: bool,
@@ -398,6 +404,8 @@ figure.report-figure figcaption { margin-top: 0.5rem; font-size: 0.85rem;
    so a phone still reads it. */
 .split-block { display: grid; grid-template-columns: 1fr 1fr; gap: 2.5vw;
   align-items: center; }
+.split-block--stacked { grid-template-columns: 1fr; grid-auto-rows: auto;
+  gap: 1.5vh; }
 .split-col { min-width: 0; }
 .split-fig figure.report-figure { margin: 0.5rem 0; }
 .split-fig figure.report-figure img { max-height: 74vh; }

--- a/spyde/actions/report/handlers.py
+++ b/spyde/actions/report/handlers.py
@@ -2222,6 +2222,25 @@ def report_add_split_cell(session, plot, payload) -> None:
     mgr.emit_state()
 
 
+def report_add_figure_placeholder(session, plot, payload) -> None:
+    """Add an EMPTY placeholder figure cell — a dashed drop-zone that becomes a
+    live figure when the user drops a window onto it (via ``report_add_figure``
+    with ``at_cell`` = this cell). Used by the "Add figure slide" action.
+
+    ``payload``: ``{index?, slide_break?, caption?}``. Mirrors
+    :func:`report_add_split_cell` for the seed-time fields (so a figure slide can
+    be created already slide-break-marked). The placeholder render + drop wiring
+    already exist in ``ReportFigureCell.tsx``."""
+    mgr = _ensure_open(session)
+    cell = Cell(id=new_cell_id(), cell_type="figure", placeholder=True,
+                caption=str(payload.get("caption", "") or ""))
+    if payload.get("slide_break") is not None:
+        cell.slide_break = bool(payload.get("slide_break"))
+    _insert_cell(mgr.doc, cell, payload.get("index"))
+    mgr.dirty = True
+    mgr.emit_state()
+
+
 def report_set_split_layout(session, plot, payload) -> None:
     """Set a SPLIT cell's ``split_layout`` — ``"text-left"`` (text on the left,
     figure on the right — the default) or ``"text-right"`` (mirror). Any other

--- a/spyde/actions/report/model.py
+++ b/spyde/actions/report/model.py
@@ -173,14 +173,15 @@ _SLIDE_STYLES = ("plain", "accent")
 _SPLIT_RE = re.compile(
     r"^<!--\s*spyde:split\s+(?P<layout>\S+)\s+(?P<cid>\S+)\s+(?P<text>\S+)\s*-->\s*$")
 # The accepted split layouts (anything else → "text-left", the default). Which
-# side the TEXT sits on; the figure/photo takes the other side.
-_SPLIT_LAYOUTS = ("text-left", "text-right")
+# side the TEXT sits on relative to the figure/photo: left / right (side by side)
+# or top / bottom (stacked).
+_SPLIT_LAYOUTS = ("text-left", "text-right", "text-top", "text-bottom")
 
 
 def _normalize_split_layout(val) -> str:
-    """Normalise a raw split layout to one of ``{"text-left", "text-right"}``.
-    Any unknown/absent value collapses to ``"text-left"`` (the default — text on
-    the left, figure on the right) so a malformed marker still renders sanely."""
+    """Normalise a raw split layout to one of :data:`_SPLIT_LAYOUTS`. Any
+    unknown/absent value collapses to ``"text-left"`` (the default — text on the
+    left, figure on the right) so a malformed marker still renders sanely."""
     s = str(val or "").strip().lower()
     return s if s in _SPLIT_LAYOUTS else "text-left"
 

--- a/spyde/tests/migrated/test_report_split_cell.py
+++ b/spyde/tests/migrated/test_report_split_cell.py
@@ -325,6 +325,40 @@ class TestSplitHandlers:
                                   {"cell_id": cid, "layout": "bogus"})
         assert _cells(messages)[0]["split_layout"] == "text-left"
 
+    def test_set_split_layout_stacked(self, window):
+        # The stacked layouts (text-top / text-bottom) are accepted + round-trip.
+        session, messages = window["window"], window["messages"]
+        h.report_new(session, None, {})
+        h.report_add_split_cell(session, None, {"source": "x"})
+        cid = _cells(messages)[0]["id"]
+        for lay in ("text-top", "text-bottom"):
+            h.report_set_split_layout(session, None, {"cell_id": cid, "layout": lay})
+            assert _cells(messages)[0]["split_layout"] == lay
+
+
+class TestFigurePlaceholderSlide:
+    def test_add_figure_placeholder(self, window):
+        # "Add figure slide" creates an empty placeholder figure cell (dashed
+        # drop-zone) — with slide_break so it's its own slide.
+        session, messages = window["window"], window["messages"]
+        h.report_new(session, None, {"type": "presentation"})
+        h.report_add_figure_placeholder(session, None, {"slide_break": True})
+        cells = _cells(messages)
+        fig = next(c for c in cells if c["cell_type"] == "figure")
+        assert fig["placeholder"] is True
+        assert fig["slide_break"] is True
+
+    def test_figure_placeholder_roundtrips(self, window, tmp_path):
+        session, messages = window["window"], window["messages"]
+        h.report_new(session, None, {"type": "presentation"})
+        h.report_add_figure_placeholder(session, None, {"slide_break": True})
+        mgr = session._report
+        p = str(tmp_path / "p.spyde-report")
+        write_report(mgr.doc, p, mgr.assemble_assets({}))
+        doc2, _ = read_report(p)
+        fig = next(c for c in doc2.cells if c.cell_type == "figure")
+        assert fig.placeholder is True and fig.slide_break is True
+
     def test_update_cell_edits_split_text(self, window):
         session, messages = window["window"], window["messages"]
         h.report_new(session, None, {})
@@ -500,5 +534,19 @@ class TestSplitExport:
         mgr2, _cid2 = self._mgr_with_photo_split(session2, messages2,
                                                  layout="text-right")
         html2 = _render_static(mgr2)
+        assert html2.index("split-fig") < html2.index("split-text")
+
+    def test_stacked_layout_export(self, window):
+        # text-top → text before figure + the --stacked modifier class (rows).
+        session, messages = window["window"], window["messages"]
+        mgr, _cid = self._mgr_with_photo_split(session, messages, layout="text-top")
+        html = _render_static(mgr)
+        assert "split-block--stacked" in html
+        assert html.index("split-text") < html.index("split-fig")
+        # text-bottom → figure before text, still stacked.
+        session2, messages2 = window["window"], window["messages"]
+        mgr2, _cid2 = self._mgr_with_photo_split(session2, messages2, layout="text-bottom")
+        html2 = _render_static(mgr2)
+        assert "split-block--stacked" in html2
         assert html2.index("split-fig") < html2.index("split-text")
 


### PR DESCRIPTION
Fixes four presentation-authoring issues from in-app use.

## 1. Add-slide menu → four clear options
The "+ Add slide" menu now offers **Add text slide · Add split slide · Add title slide · Add figure slide**. The figure slide is new — it creates an empty placeholder figure cell (a dashed drop-zone) as its own slide via a new `report_add_figure_placeholder` handler (previously `report_add_figure` required a live source, so there was no way to add an empty figure slide).

## 2. Split-cell editing works in a presentation
A split slide (text + figure) is now fully editable in a presentation: text edits persist, the figure drop-zone works, and the layout is chosen via a dropdown.

## 3. Stacked split layouts + dropdown picker
The split layout switch (was a single swap button, left↔right only) is now a **dropdown with four arrangements**: text left / right (side-by-side) and text top / bottom (**stacked**). The editor panes grid switches between 2 columns and 2 rows; the HTML/slides export renders a `--stacked` modifier and orders the sides correctly. `_SPLIT_LAYOUTS` gains `text-top` / `text-bottom` (SCHEMA unchanged; older `text-left`/`text-right` still valid).

## 4. Presenter view has an explicit exit
The presenter dashboard (z20) covered the top-right controls (z10), trapping the user (only Esc/S keys worked). Added **"Audience view"** (leave presenter, stay in Present) and **"✕ Exit"** (leave Present) buttons in the presenter header.

## Testing
- pytest `test_report_split_cell.py`: stacked layout set + round-trip, stacked HTML export, figure-placeholder create + zip round-trip (30 passing).
- e2e `presentation_editing.spec.ts`: the 4-option menu + figure slide, split-slide editing in a presentation (text persists, 4-arrangement dropdown, text-top persists), presenter exit controls clickable.
- No regressions: `slide_native.spec.ts` (8) green.

Screenshots confirm the Add-slide menu, the split layout dropdown, and the presenter-view exit controls.