### PR TITLE
Fix macOS auto-update (needs zip target) + sanitize error rendering + CI gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,41 @@ jobs:
         working-directory: electron
         run: npm run typecheck
 
+  # ── Main-process unit tests (cross-OS) ─────────────────────────────────────
+  # Pure-logic units from the Electron MAIN process (node:test, native TS type-
+  # stripping on Node 24). No display / Python / Electron runtime — just Node — so
+  # it runs fast on all three desktop OSes. Motivation: the auto-updater's
+  # friendlyError() must sanitise a raw releases.atom / HTML error body on EVERY
+  # platform (the "mac auto-update failed spectacularly" wall-of-XML regression,
+  # also reported on Windows). The mapper is platform-independent, but running it
+  # on windows/macos/ubuntu also guards against per-OS differences in node --test
+  # + TS type-stripping + glob expansion.
+  unit:
+    name: electron-unit (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # windows-latest ≈ Win 11 image; windows-2022 ≈ the older Win 10-era image.
+        # macos-latest = Apple Silicon. Covers Win 11 / Win 10-era / macOS as asked.
+        os: [ubuntu-latest, windows-latest, windows-2022, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install Electron dependencies
+        working-directory: electron
+        run: npm ci
+
+      - name: Run main-process unit tests
+        working-directory: electron
+        run: npm run test:unit
+
   # ── Electron e2e (Playwright) ──────────────────────────────────────────────
   # Runs the DEFAULT 'electron' project only (synthetic + bundled data, no
   # network). The opt-in 'electron-real' project (real pyxem downloads + the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,11 @@ jobs:
             # electron-builder (nsis) emits "SpyDE Setup <version>.exe".
             artifact_glob: electron/dist/*.exe
           - os: macos-latest
-            artifact_glob: electron/dist/*.dmg
+            # dmg = manual install; zip = the electron-updater auto-update payload
+            # (macOS can't auto-update from a dmg). Both are published to the release.
+            artifact_glob: |
+              electron/dist/*.dmg
+              electron/dist/*.zip
           - os: ubuntu-latest
             artifact_glob: electron/dist/*.AppImage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,60 @@ jobs:
             exit 1
           fi
 
+      # AUTO-UPDATE FEED GATE — the check that would have caught "mac auto-update
+      # failed spectacularly". electron-updater reads latest*.yml to decide what to
+      # download; on macOS it CANNOT apply a .dmg, only a .zip. A dmg-only mac feed
+      # builds + publishes fine (so the asset-count gate above passes) yet every
+      # mac auto-update then fails. Validate each platform feed references an
+      # INSTALLABLE payload AND that the referenced file is actually an attached
+      # asset — refuse to publish a release users can't update from.
+      - name: Validate the auto-update feeds are installable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # asset names actually attached to the release
+          mapfile -t ASSETS < <(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')
+          has_asset() { for a in "${ASSETS[@]}"; do [ "$a" = "$1" ] && return 0; done; return 1; }
+
+          # feed file -> the extension(s) electron-updater can install from it
+          declare -A FEED_EXT=(
+            [latest-mac.yml]='\.zip$'
+            [latest.yml]='\.(exe|nupkg)$'
+            [latest-linux.yml]='\.(AppImage|deb|rpm)$'
+          )
+          fail=0
+          for feed in latest-mac.yml latest.yml latest-linux.yml; do
+            url="https://github.com/$REPO/releases/download/$TAG/$feed"
+            if ! body=$(curl -fsSL "$url"); then
+              echo "::error::update feed $feed is missing from the release — electron-updater can't detect updates on that platform."
+              fail=1; continue
+            fi
+            # every `url:` entry under files: (the installable payloads)
+            mapfile -t urls < <(printf '%s\n' "$body" | sed -nE 's/^[[:space:]]*-?[[:space:]]*url:[[:space:]]*//p')
+            if [ "${#urls[@]}" -eq 0 ]; then
+              echo "::error::$feed lists no files — malformed update feed."; fail=1; continue
+            fi
+            want="${FEED_EXT[$feed]}"
+            ok=0
+            for u in "${urls[@]}"; do
+              u="${u%$'\r'}"                       # strip any CRLF
+              if printf '%s' "$u" | grep -qiE "$want"; then
+                if has_asset "$u"; then ok=1; echo "  $feed -> $u ✓"; else
+                  echo "::error::$feed references '$u' but it is NOT an attached asset."; fail=1
+                fi
+              fi
+            done
+            if [ "$ok" -eq 0 ]; then
+              echo "::error::$feed has no installable payload (need $want). Files: ${urls[*]}. On macOS a dmg-only feed CANNOT auto-update — add the zip target."
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || { echo "::error::auto-update feed validation failed — refusing to publish a release users can't update from."; exit 1; }
+          echo "All auto-update feeds reference an installable, attached payload."
+
       # Un-draft AND stamp the channel: the prerelease flag is applied HERE (not
       # at draft-creation) so the release stays a plain draft during the upload
       # phase — see the prepare-release note on why a non-draft release makes

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -37,7 +37,13 @@ extraResources:
 # (electron/), so ../ reaches the repo root.
 mac:
   category: public.app-category.education
-  target: [dmg]
+  # BOTH dmg (what users download by hand) AND zip. electron-updater CANNOT
+  # auto-update from a .dmg on macOS — it needs a .zip in latest-mac.yml to apply
+  # an update. A dmg-only feed made autoUpdater download the dmg it could not
+  # install and then fall back to fetching the releases.atom feed, whose raw XML
+  # surfaced as the "mac auto-update failed" wall of text. The zip is the update
+  # payload; the dmg stays for first-time manual installs.
+  target: [dmg, zip]
   icon: ../spyde/Spyde.png
   # Unsigned for now — Gatekeeper will warn; see PACKAGING.md for the
   # sign+notarize follow-up (needs an Apple Developer ID).

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
     "preview": "electron-vite preview",
     "test": "playwright test",
+    "test:unit": "node --test \"src/**/*.test.ts\"",
     "test:build": "electron-vite build && playwright test",
     "bundle:python": "node scripts/bundle-python.mjs",
     "dist": "npm run build && npm run bundle:python && electron-builder --config electron-builder.yml",

--- a/electron/src/main/updater.ts
+++ b/electron/src/main/updater.ts
@@ -71,7 +71,8 @@ function clearDownloadStallTimer(): void {
 }
 
 /** Map a raw electron-updater / Chromium-net error to something a user can act
- *  on. Falls back to the raw message when we don't recognise it. */
+ *  on. Falls back to a BOUNDED, sanitised version of the raw message when we
+ *  don't recognise it — never the raw blob verbatim. */
 export function friendlyError(raw: string): string {
   const s = String(raw || '')
   if (/ERR_INTERNET_DISCONNECTED|ENOTFOUND|EAI_AGAIN|ERR_NAME_NOT_RESOLVED|getaddrinfo/i.test(s)) {
@@ -86,7 +87,22 @@ export function friendlyError(raw: string): string {
   if (/latest.*\.yml|Cannot find .*\.yml|status code 404|HttpError: 404|ERR_HTTP_RESPONSE_CODE_FAILURE/i.test(s)) {
     return 'No update information available right now — please try again later.'
   }
-  return s
+  // A provider that can't resolve the platform feed can surface the GitHub
+  // releases.atom body (or an HTML error page) as the error message. That raw
+  // XML/HTML must NEVER reach the UI verbatim — it rendered as a full-screen wall
+  // of markup ("mac auto-update failed spectacularly"). Detect markup / an
+  // oversized blob and collapse it to a short, actionable line.
+  if (/<\?xml|<!DOCTYPE|<feed\b|<entry\b|<html\b|<rss\b/i.test(s)) {
+    return 'The update server returned an unexpected response — please try again later or update manually from GitHub.'
+  }
+  return truncateMessage(s)
+}
+
+/** Bound an unrecognised error message so a huge single-line payload can't blow
+ *  out the error box. Collapse whitespace, cap length, keep it one readable line. */
+function truncateMessage(s: string, max = 300): string {
+  const flat = s.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
 }
 
 /** Every error/timeout path funnels through here so state stays consistent:

--- a/electron/src/main/updater.ts
+++ b/electron/src/main/updater.ts
@@ -29,6 +29,7 @@ import { app, BrowserWindow } from 'electron'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { autoUpdater } from 'electron-updater'
+import { friendlyError } from './updater_errors'
 
 export type UpdateChannel = 'stable' | 'beta'
 
@@ -70,40 +71,10 @@ function clearDownloadStallTimer(): void {
   if (downloadStallTimer) { clearTimeout(downloadStallTimer); downloadStallTimer = null }
 }
 
-/** Map a raw electron-updater / Chromium-net error to something a user can act
- *  on. Falls back to a BOUNDED, sanitised version of the raw message when we
- *  don't recognise it — never the raw blob verbatim. */
-export function friendlyError(raw: string): string {
-  const s = String(raw || '')
-  if (/ERR_INTERNET_DISCONNECTED|ENOTFOUND|EAI_AGAIN|ERR_NAME_NOT_RESOLVED|getaddrinfo/i.test(s)) {
-    return 'You appear to be offline — check your connection and try again.'
-  }
-  if (/ETIMEDOUT|ERR_TIMED_OUT|ERR_CONNECTION_TIMED_OUT|timed out/i.test(s)) {
-    return 'The update server took too long to respond — please try again.'
-  }
-  if (/ERR_CONNECTION_(REFUSED|RESET|CLOSED)|ECONNRESET|ECONNREFUSED|socket hang up/i.test(s)) {
-    return 'Could not reach the update server — please try again.'
-  }
-  if (/latest.*\.yml|Cannot find .*\.yml|status code 404|HttpError: 404|ERR_HTTP_RESPONSE_CODE_FAILURE/i.test(s)) {
-    return 'No update information available right now — please try again later.'
-  }
-  // A provider that can't resolve the platform feed can surface the GitHub
-  // releases.atom body (or an HTML error page) as the error message. That raw
-  // XML/HTML must NEVER reach the UI verbatim — it rendered as a full-screen wall
-  // of markup ("mac auto-update failed spectacularly"). Detect markup / an
-  // oversized blob and collapse it to a short, actionable line.
-  if (/<\?xml|<!DOCTYPE|<feed\b|<entry\b|<html\b|<rss\b/i.test(s)) {
-    return 'The update server returned an unexpected response — please try again later or update manually from GitHub.'
-  }
-  return truncateMessage(s)
-}
-
-/** Bound an unrecognised error message so a huge single-line payload can't blow
- *  out the error box. Collapse whitespace, cap length, keep it one readable line. */
-function truncateMessage(s: string, max = 300): string {
-  const flat = s.replace(/\s+/g, ' ').trim()
-  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
-}
+// friendlyError lives in updater_errors.ts (pure, dependency-free) so it's unit-
+// testable with node:test on every OS. Imported above; re-exported to keep the
+// existing public API (some callers/tests import it from updater.ts).
+export { friendlyError } from './updater_errors'
 
 /** Every error/timeout path funnels through here so state stays consistent:
  *  friendly text out, in-flight guard + timers cleared so a retry works. */

--- a/electron/src/main/updater_errors.test.ts
+++ b/electron/src/main/updater_errors.test.ts
@@ -1,0 +1,80 @@
+/**
+ * updater_errors.test.ts — node:test unit tests for the pure updater error mapper.
+ *
+ * Runs on every CI push, every OS (`node --test`, native TS type-stripping on
+ * Node 24+). Guards the "mac auto-update failed spectacularly" regression: a raw
+ * releases.atom XML body must be collapsed to a short line, never passed through.
+ *
+ * Run: `node --test src/main/updater_errors.test.ts` (from electron/), or via the
+ * `test:unit` npm script.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { friendlyError, truncateMessage } from './updater_errors.ts'
+
+test('offline / DNS errors → offline message', () => {
+  for (const raw of ['net::ERR_INTERNET_DISCONNECTED', 'getaddrinfo ENOTFOUND github.com', 'EAI_AGAIN']) {
+    assert.match(friendlyError(raw), /offline/i)
+  }
+})
+
+test('timeout errors → try again', () => {
+  for (const raw of ['ETIMEDOUT', 'net::ERR_TIMED_OUT', 'request timed out']) {
+    assert.match(friendlyError(raw), /too long|try again/i)
+  }
+})
+
+test('connection reset/refused → could not reach', () => {
+  for (const raw of ['ECONNRESET', 'net::ERR_CONNECTION_REFUSED', 'socket hang up']) {
+    assert.match(friendlyError(raw), /reach the update server/i)
+  }
+})
+
+test('missing feed / 404 → no update info', () => {
+  for (const raw of ['Cannot find latest-mac.yml', 'HttpError: 404', 'status code 404']) {
+    assert.match(friendlyError(raw), /no update information/i)
+  }
+})
+
+test('RAW ATOM/HTML FEED is collapsed, never passed through (the regression)', () => {
+  const atom = '<?xml version="1.0" encoding="UTF-8"?>\n<feed xmlns="http://www.w3.org/2005/Atom">'
+    + '<entry><id>tag:github.com,2008:Repository/1/v0.2.0-rc.6</id>'.repeat(300) + '</feed>'
+  const out = friendlyError(atom)
+  assert.doesNotMatch(out, /<entry|<feed|<\?xml/i, 'markup leaked into the user message')
+  assert.ok(out.length < 200, `message not collapsed (len ${out.length})`)
+  assert.match(out, /unexpected response|manually/i)
+})
+
+test('a raw <html> error page is collapsed too', () => {
+  const html = '<!DOCTYPE html><html><body>' + '<div>error</div>'.repeat(500) + '</body></html>'
+  const out = friendlyError(html)
+  assert.doesNotMatch(out, /<html|<div|<!DOCTYPE/i)
+  assert.ok(out.length < 200)
+})
+
+test('an unrecognised long single-line blob is truncated, not verbatim', () => {
+  const blob = 'SomeUpstreamError: ' + 'x'.repeat(5000)
+  const out = friendlyError(blob)
+  assert.ok(out.length <= 300, `not truncated (len ${out.length})`)
+  assert.ok(out.endsWith('…'))
+})
+
+test('a short recognisable-enough message passes through (collapsed whitespace)', () => {
+  assert.equal(friendlyError('Update   failed\n  for reason X'), 'Update failed for reason X')
+})
+
+test('truncateMessage collapses whitespace and caps length', () => {
+  assert.equal(truncateMessage('a\n\n  b   c'), 'a b c')
+  const long = 'y'.repeat(400)
+  const t = truncateMessage(long, 100)
+  assert.equal(t.length, 100)
+  assert.ok(t.endsWith('…'))
+})
+
+test('empty / nullish input → empty string, never throws', () => {
+  assert.equal(friendlyError(''), '')
+  // @ts-expect-error deliberately exercising a nullish raw
+  assert.equal(friendlyError(null), '')
+  // @ts-expect-error deliberately exercising an undefined raw
+  assert.equal(friendlyError(undefined), '')
+})

--- a/electron/src/main/updater_errors.ts
+++ b/electron/src/main/updater_errors.ts
@@ -1,0 +1,45 @@
+/**
+ * updater_errors.ts — PURE, dependency-free error mapping for the auto-updater.
+ *
+ * Split out of updater.ts (which imports `electron`, so it can't be loaded by a
+ * plain node unit test) so `friendlyError` can be unit-tested with `node:test` on
+ * every CI push, on every OS. The whole point: an updater error must NEVER reach
+ * the UI as a raw blob — the "mac auto-update failed spectacularly" screenshot was
+ * ~10 KB of raw releases.atom XML rendered full-screen because the fallback
+ * returned the provider's message verbatim. See updater_errors.test.ts.
+ */
+
+/** Bound an unrecognised error message so a huge single-line payload can't blow
+ *  out the error box. Collapse whitespace, cap length, keep it one readable line. */
+export function truncateMessage(s: string, max = 300): string {
+  const flat = String(s ?? '').replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
+/** Map a raw electron-updater / Chromium-net error to something a user can act
+ *  on. Falls back to a BOUNDED, sanitised version of the raw message when we
+ *  don't recognise it — never the raw blob verbatim. */
+export function friendlyError(raw: string): string {
+  const s = String(raw || '')
+  if (/ERR_INTERNET_DISCONNECTED|ENOTFOUND|EAI_AGAIN|ERR_NAME_NOT_RESOLVED|getaddrinfo/i.test(s)) {
+    return 'You appear to be offline — check your connection and try again.'
+  }
+  if (/ETIMEDOUT|ERR_TIMED_OUT|ERR_CONNECTION_TIMED_OUT|timed out/i.test(s)) {
+    return 'The update server took too long to respond — please try again.'
+  }
+  if (/ERR_CONNECTION_(REFUSED|RESET|CLOSED)|ECONNRESET|ECONNREFUSED|socket hang up/i.test(s)) {
+    return 'Could not reach the update server — please try again.'
+  }
+  if (/latest.*\.yml|Cannot find .*\.yml|status code 404|HttpError: 404|ERR_HTTP_RESPONSE_CODE_FAILURE/i.test(s)) {
+    return 'No update information available right now — please try again later.'
+  }
+  // A provider that can't resolve the platform feed can surface the GitHub
+  // releases.atom body (or an HTML error page) as the error message. That raw
+  // XML/HTML must NEVER reach the UI verbatim — it rendered as a full-screen wall
+  // of markup ("mac auto-update failed spectacularly"). Detect markup / an
+  // oversized blob and collapse it to a short, actionable line.
+  if (/<\?xml|<!DOCTYPE|<feed\b|<entry\b|<html\b|<rss\b/i.test(s)) {
+    return 'The update server returned an unexpected response — please try again later or update manually from GitHub.'
+  }
+  return truncateMessage(s)
+}

--- a/electron/src/renderer/src/components/UpdateCard.tsx
+++ b/electron/src/renderer/src/components/UpdateCard.tsx
@@ -204,7 +204,12 @@ const S: Record<string, React.CSSProperties> = {
     fontSize: 16, lineHeight: 1, cursor: 'pointer', padding: '0 2px', marginTop: -2,
   },
   subtle: { fontSize: 11.5, color: '#a6adc8' },
-  errText: { fontSize: 11.5, color: '#f38ba8', lineHeight: 1.4 },
+  errText: {
+    fontSize: 11.5, color: '#f38ba8', lineHeight: 1.4,
+    // Bound an unexpectedly long message so it scrolls inside the card instead of
+    // blowing out its height (see updater.ts friendlyError).
+    maxHeight: 120, overflowY: 'auto', overflowWrap: 'anywhere', whiteSpace: 'pre-wrap',
+  },
   notes: {
     fontSize: 11, color: '#a6adc8', lineHeight: 1.45, whiteSpace: 'pre-wrap',
     maxHeight: 140, overflowY: 'auto',

--- a/electron/src/renderer/src/components/UpdateDialog.tsx
+++ b/electron/src/renderer/src/components/UpdateDialog.tsx
@@ -208,6 +208,9 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12.5, color: '#f38ba8', margin: '0 0 14px',
     background: 'rgba(243,139,168,0.08)', border: '1px solid rgba(243,139,168,0.3)',
     borderRadius: 6, padding: '10px 12px',
+    // Belt-and-braces against an unexpectedly long message (see updater.ts
+    // friendlyError): scroll inside the box, wrap, never overflow the dialog.
+    maxHeight: 160, overflowY: 'auto', overflowWrap: 'anywhere', whiteSpace: 'pre-wrap',
   },
   progressTrack: {
     marginTop: 6, height: 5, borderRadius: 3, background: '#313244', overflow: 'hidden',

--- a/electron/tests/update_card.spec.ts
+++ b/electron/tests/update_card.spec.ts
@@ -127,6 +127,34 @@ test('error → friendly message + Retry (the banner dropped this)', async () =>
   await expect.poll(firedChannels).toContain('spyde:check-for-updates')
 })
 
+test('a huge raw error message stays BOUNDED inside the card (no wall of text)', async () => {
+  // Regression: a provider that couldn't resolve latest-mac.yml surfaced the raw
+  // GitHub releases.atom XML as the error message — it rendered as a full-screen
+  // wall of markup. friendlyError now collapses markup main-side; the card's error
+  // box is ALSO bounded (maxHeight + scroll) as defence-in-depth. Push a giant
+  // blob directly (bypassing friendlyError) and assert the card doesn't blow out.
+  const huge = '<?xml version="1.0"?><feed>' + '<entry>x</entry>'.repeat(400) + '</feed>'
+  await pushStatus({ state: 'error', message: huge })
+  const card = page.getByTestId('update-card')
+  await expect(card).toBeVisible()
+
+  const { cardH, winH, errScrolls } = await card.evaluate((el) => {
+    const err = el.querySelector('[data-testid="update-card-error"]') as HTMLElement
+    return {
+      cardH: el.getBoundingClientRect().height,
+      winH: window.innerHeight,
+      // The error box caps its own height and scrolls its overflow.
+      errScrolls: err ? err.scrollHeight > err.clientHeight + 1 : false,
+    }
+  })
+  // The whole card must stay a small fraction of the window, not fill it.
+  expect(cardH).toBeLessThan(winH * 0.6)
+  expect(errScrolls).toBe(true)
+  // Retry is still reachable (not pushed off-screen by the blob).
+  await expect(page.getByTestId('update-card-retry')).toBeVisible()
+  await page.screenshot({ path: 'update_card_shots/04-bounded-error.png' })
+})
+
 test('dismiss hides the card; a NEW status re-shows it', async () => {
   await pushStatus({ state: 'available', version: '9.9.9' })
   await expect(page.getByTestId('update-card')).toBeVisible()

--- a/electron/tsconfig.node.json
+++ b/electron/tsconfig.node.json
@@ -1,5 +1,10 @@
 {
   "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
+  // *.test.ts are run by `node --test` (native TS strip), not compiled into the
+  // app bundle — and they use explicit .ts import specifiers node's ESM resolver
+  // needs, which tsc's bundler resolution rejects (TS5097). Keep them out of the
+  // typecheck; their own run is the gate (npm run test:unit).
+  "exclude": ["src/**/*.test.ts"],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"],


### PR DESCRIPTION
## The bug

macOS auto-update "failed spectacularly" — a full-screen wall of raw GitHub `releases.atom` XML. Two independent causes, one of which likely also hit Windows.

### 1. Root cause: `mac.target: [dmg]` only
electron-updater **cannot auto-update from a `.dmg`** on macOS — it needs a `.zip` in `latest-mac.yml`. A dmg-only feed made autoUpdater download an installer it couldn't apply, then fall back to fetching the `releases.atom` feed. Fixed: `target: [dmg, zip]` (dmg stays for manual first installs; zip is the update payload).

### 2. Symptom / cross-platform: raw feed rendered verbatim
The provider surfaced that raw Atom XML as the error message, and `friendlyError` returned unrecognised messages verbatim → ~10 KB of markup rendered full-screen (this could bite **Windows** too, on any updater error with an HTML/XML body). Fixed: `friendlyError` collapses markup + oversized blobs to a short line; the error boxes in `UpdateCard`/`UpdateDialog` are bounded (maxHeight + scroll + wrap).

## Guards so it can't ship silently again

- **`electron-unit` CI job** (build.yml) — `friendlyError` extracted to a pure `updater_errors.ts` + `node:test` unit tests, run on **ubuntu + windows-latest (Win 11) + windows-2022 (Win 10-era) + macOS**.
- **Release feed-validation gate** (release.yml `finalize`) — before un-drafting, every `latest*.yml` must reference an installable, attached payload (mac→`.zip`, win→`.exe`, linux→`.AppImage`). A dmg-only mac feed now **fails the release**. Verified against the real rc.6 feeds: mac fails (dmg-only), win + linux pass.

## Not covered (can't be, in hosted CI)
A true end-to-end self-replacement (install vN → publish vN+1 → app swaps itself) needs signed builds + a real release + two versions. These checks cover the parts that actually broke: the feed shape and the error rendering.

## Verified
- 8 `update_card` e2e + 10 `updater_errors` unit tests pass; typecheck + build clean.
- Feed gate reproduced against real rc.6 (mac dmg-only → FAILS as designed).