### PR TITLE
Fix release feed-validation gate: read feeds via API (runs on a draft)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,13 +331,22 @@ jobs:
             [latest.yml]='\.(exe|nupkg)$'
             [latest-linux.yml]='\.(AppImage|deb|rpm)$'
           )
+          # This step runs while the release is STILL A DRAFT (finalize un-drafts it
+          # AFTER this passes). Draft assets are NOT reachable at the public
+          # releases/download/<tag>/ URL (404), so fetch them through the API with
+          # `gh release download`, which authenticates and sees the draft.
+          tmp=$(mktemp -d)
           fail=0
           for feed in latest-mac.yml latest.yml latest-linux.yml; do
-            url="https://github.com/$REPO/releases/download/$TAG/$feed"
-            if ! body=$(curl -fsSL "$url"); then
-              echo "::error::update feed $feed is missing from the release — electron-updater can't detect updates on that platform."
+            if ! has_asset "$feed"; then
+              echo "::error::update feed $feed is not attached to the release — electron-updater can't detect updates on that platform."
               fail=1; continue
             fi
+            if ! gh release download "$TAG" --repo "$REPO" --pattern "$feed" --dir "$tmp" --clobber; then
+              echo "::error::could not download update feed $feed from the (draft) release."
+              fail=1; continue
+            fi
+            body=$(cat "$tmp/$feed")
             # every `url:` entry under files: (the installable payloads)
             mapfile -t urls < <(printf '%s\n' "$body" | sed -nE 's/^[[:space:]]*-?[[:space:]]*url:[[:space:]]*//p')
             if [ "${#urls[@]}" -eq 0 ]; then


### PR DESCRIPTION
The auto-update feed-validation gate added in the mac-updater fix blocked v0.2.0-rc.7 — a false failure.

**Bug:** the gate `curl`s `latest*.yml` from `https://github.com/OWNER/REPO/releases/download/<tag>/…`. But it runs in the `finalize` job *before* the release is un-drafted, and **draft assets 404 at that public URL**. Every feed read failed → the gate reported "feed missing" → the release stayed a draft, even though the build was correct and DID contain the new mac `.zip`.

**Fix:** fetch each feed with `gh release download` (authenticated, sees drafts) instead of the public URL, and check the feed is an attached asset first.

**Verified** against the real rc.7 draft: `latest-mac.yml → SpyDE-*-arm64-mac.zip`, `latest.yml → *.exe`, `latest-linux.yml → *.AppImage` all pass. rc.7 was finalized manually (build confirmed sound); this makes the next release finalize automatically.