### PR TITLE
Enable macOS code signing + notarization on release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,11 @@ jobs:
     needs: [channel, prepare-release]
     permissions:
       contents: write      # electron-builder publishes assets to the release
+    # The `secrets` context is NOT available in step-level `if:` — only `env` is.
+    # So surface "is the mac cert configured?" as a job-level env flag the signing
+    # steps can gate on (a fork / secret-less run then produces an unsigned build).
+    env:
+      MAC_SIGNING_ENABLED: ${{ secrets.MAC_CERT_P12_BASE64 != '' && 'true' || 'false' }}
     # windows-latest's default step shell is PowerShell, which killed two
     # v0.1.0 attempts (ParserError on the bash version-guard script; then
     # npm.cmd arg-mangling that turned -c.publish.repo=spyde into a config
@@ -237,13 +242,53 @@ jobs:
         working-directory: electron
         run: npm ci
 
+      # ── macOS code signing (only when secrets are present) ─────────────────────
+      # Import the Developer ID Application cert into a throwaway keychain so
+      # electron-builder can sign + (with notarize:true) notarize. See SIGNING.md.
+      # Gated on both runner.os == macOS AND the cert secret being set, so a fork
+      # / secret-less run skips it and electron-builder produces an unsigned build
+      # (rather than failing) — matching electron-builder.yml's no-identity-null.
+      - name: Import Apple signing certificate (macOS only)
+        if: runner.os == 'macOS' && env.MAC_SIGNING_ENABLED == 'true'
+        env:
+          MAC_CERT_P12_BASE64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN=build.keychain
+          KEYCHAIN_PW=$(openssl rand -base64 24)
+          echo "$MAC_CERT_P12_BASE64" | base64 --decode > cert.p12
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security import cert.p12 -k "$KEYCHAIN" -P "$MAC_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          # Ensure the Developer ID G2 intermediate is present so codesign can build
+          # the chain even if the .p12 didn't bundle it.
+          curl -fsSO https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+          security import DeveloperIDG2CA.cer -k "$KEYCHAIN" || true
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PW" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          rm -f cert.p12 DeveloperIDG2CA.cer
+          # Sanity: the signing identity is now findable.
+          security find-identity -v -p codesigning "$KEYCHAIN"
+
+      # Write the App Store Connect API key to a file; electron-builder's notarize
+      # step wants APPLE_API_KEY as a PATH to the .p8.
+      - name: Stage notarization API key (macOS only)
+        if: runner.os == 'macOS' && env.MAC_SIGNING_ENABLED == 'true'
+        run: |
+          printf '%s' "${{ secrets.APPLE_API_KEY_P8 }}" > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
       # Build renderer/main → stage the Python sidecar payload → electron-builder
       # --publish always. electron-builder finds the draft `prepare-release`
       # already created (by tag) and uploads this platform's installer PLUS the
       # update-feed metadata (latest.yml / latest-mac.yml / latest-linux.yml)
       # electron-updater's autoUpdater reads at runtime — publish:false builds
-      # never generate these files at all. Unsigned for now — signing secrets
-      # are a follow-up (PACKAGING.md "What's intentionally deferred").
+      # never generate these files at all. On macOS the app is signed + notarized
+      # when MAC_SIGNING_ENABLED (see the signing steps above + SIGNING.md).
       # -c.publish.owner/.repo pin the publish target to THE REPO THIS WORKFLOW
       # RUNS IN — the same-repo assumption the draft-release design above already
       # makes (GITHUB_TOKEN can't publish cross-repo anyway). Without the
@@ -272,6 +317,13 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS notarization (electron-builder's notarize:true reads these). Empty
+          # on non-mac legs / secret-less runs → notarization is simply skipped there.
+          # APPLE_API_KEY is a PATH, set by the "Stage notarization API key" step.
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload build artifact (for release-notes / manual inspection)
         uses: actions/upload-artifact@v4

--- a/electron/SIGNING.md
+++ b/electron/SIGNING.md
@@ -5,10 +5,15 @@ users stop hitting the Gatekeeper "unidentified developer" wall — and so the
 auto-update `.zip` is trusted too (electron-updater applies a notarized zip
 without a warning).
 
-> **Status:** the repo ships **unsigned** today (`electron-builder.yml` has
-> `mac.identity: null`). This doc is the checklist to flip it on once you have an
-> Apple Developer account ($99/yr). The entitlements file it references already
-> exists: [`build/entitlements.mac.plist`](build/entitlements.mac.plist).
+> **Status: WIRED (2026-07-21).** `electron-builder.yml` has
+> `hardenedRuntime`/`entitlements`/`notarize: true`, and `release.yml`'s mac leg
+> imports the cert + stages the notarization key, gated on the job-level
+> `MAC_SIGNING_ENABLED` flag (true when the `MAC_CERT_P12_BASE64` secret is set).
+> The six secrets below are configured, so **the next release build signs +
+> notarizes automatically**. A local `npm run dist` or a fork build with no
+> secrets still produces an *unsigned* build (electron-builder logs "skipped macOS
+> code signing") rather than failing. Steps 1–4 below are the one-time cert/secret
+> setup (done); steps 5–7 document what's now wired + how to verify.
 
 ## What "signing an Apple app" means (two required steps)
 

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -45,9 +45,26 @@ mac:
   # payload; the dmg stays for first-time manual installs.
   target: [dmg, zip]
   icon: ../spyde/Spyde.png
-  # Unsigned for now — Gatekeeper will warn; see PACKAGING.md for the
-  # sign+notarize follow-up (needs an Apple Developer ID).
-  identity: null
+  # Code signing + notarization — see SIGNING.md. The Developer ID Application cert
+  # is imported into the CI keychain by release.yml's "Import Apple signing
+  # certificate" step; electron-builder auto-selects it. hardenedRuntime + the
+  # entitlements below are REQUIRED for notarization; disable-library-validation in
+  # particular lets the uv-managed Python sidecar load its third-party native wheels
+  # (torch/numba/rosettasciio, signed by other teams) under the hardened runtime.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  # notarize submits the signed build to Apple + staples the ticket, using the
+  # App Store Connect API-key env vars (APPLE_API_KEY[_ID]/APPLE_API_ISSUER/
+  # APPLE_TEAM_ID) that release.yml sets on the mac leg.
+  notarize: true
+  # NB: NO `identity: null` here — that would DISABLE signing. When the signing
+  # env is absent (a local `npm run dist`, or a fork build with no secrets),
+  # electron-builder logs "skipped macOS code signing" and produces an UNSIGNED
+  # build rather than failing — so dev/local builds still work; only CI with the
+  # cert imported actually signs. To force-disable signing (emergency unsigned
+  # release), set CSC_IDENTITY_AUTO_DISCOVERY=false in the build env.
 
 win:
   target: [nsis]


### PR DESCRIPTION
The six Apple secrets are configured, so this turns signing on. The next release build will sign + notarize the macOS app automatically — no more Gatekeeper "unidentified developer" wall, and the auto-update `.zip` becomes trusted too.

## Changes
- **`electron-builder.yml` `mac`:** drop `identity: null`; add `hardenedRuntime: true`, `entitlements`/`entitlementsInherit: build/entitlements.mac.plist`, `notarize: true`.
- **`release.yml` build job:** `MAC_SIGNING_ENABLED` job env flag (true iff `MAC_CERT_P12_BASE64` is set — the `secrets` context can't be used in a step `if:`, only `env`). Two mac-only steps gated on it: import the Developer ID cert into a throwaway keychain (+ fetch the G2 intermediate as a chain fallback), and stage the App Store Connect `.p8`, pointing `APPLE_API_KEY` at it. The build step gains the `APPLE_API_KEY[_ID]`/`APPLE_API_ISSUER`/`APPLE_TEAM_ID` env so `notarize: true` can submit + staple.

## Safety
- **Local / fork builds stay working** — with no signing env, electron-builder logs "skipped macOS code signing" and produces an *unsigned* build instead of failing.
- **Windows/Linux legs unchanged** — the signing steps are `runner.os == 'macOS'`-gated.
- Emergency unsigned release: set `CSC_IDENTITY_AUTO_DISCOVERY=false`.

## Verify after the next release (SIGNING.md Step 7)
`spctl -a -vvv -t install SpyDE-*.dmg` → "accepted, source=Notarized Developer ID"; also `codesign -dv --verbose=4` and `stapler validate` on both the dmg and the zip.

Both YAML files validated. Signing itself can only be exercised by a real tagged release build (the mac runner + secrets), so it can't be fully tested on this PR's CI — the guards ensure it's a no-op if anything is misconfigured.