### PR TITLE
ci: manual 'Verify signing secrets' probe

### DIFF
--- a/.github/workflows/verify_signing_secrets.yml
+++ b/.github/workflows/verify_signing_secrets.yml
@@ -1,0 +1,100 @@
+# Cheap (~1 min) manual check that the macOS signing secrets are VALID and
+# round-tripped intact — run this BEFORE cutting a release so a corrupted secret
+# (e.g. base64 copied through TextEdit, a mangled multi-line .p8) is caught in
+# seconds instead of 15 minutes into a real mac build.
+#
+# It does NOT build the app or submit anything to Apple. It:
+#   1. decodes MAC_CERT_P12_BASE64 → imports the .p12 → confirms a codesigning
+#      identity is found (proves the cert + MAC_CERT_PASSWORD are correct),
+#   2. writes APPLE_API_KEY_P8 → confirms it's a well-formed PEM private key,
+#   3. runs `notarytool history` — a read-only call that AUTHENTICATES against
+#      Apple with the API key + key-id + issuer + team-id, proving those four all
+#      work together (fails loudly if any is wrong), without submitting a build.
+#
+# Run: Actions tab → "Verify signing secrets" → Run workflow. Delete this file
+# once signing is confirmed working end-to-end, or keep it as a pre-release probe.
+name: Verify signing secrets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Verify macOS signing secrets
+    runs-on: macos-latest
+    env:
+      MAC_SIGNING_ENABLED: ${{ secrets.MAC_CERT_P12_BASE64 != '' && 'true' || 'false' }}
+    steps:
+      - name: Fail fast if secrets are not set
+        run: |
+          if [ "$MAC_SIGNING_ENABLED" != "true" ]; then
+            echo "::error::MAC_CERT_P12_BASE64 is empty — no signing secrets configured."
+            exit 1
+          fi
+
+      - name: Validate the certificate .p12
+        env:
+          MAC_CERT_P12_BASE64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # Decode — a corrupted base64 (TextEdit smart chars / wrapping) fails HERE.
+          if ! echo "$MAC_CERT_P12_BASE64" | base64 --decode > cert.p12; then
+            echo "::error::MAC_CERT_P12_BASE64 is not valid base64 — re-set it with: base64 -i certificate.p12 | gh secret set MAC_CERT_P12_BASE64"
+            exit 1
+          fi
+          bytes=$(wc -c < cert.p12)
+          echo "decoded .p12 is $bytes bytes"
+          if [ "$bytes" -lt 500 ]; then
+            echo "::error::decoded .p12 is suspiciously small ($bytes bytes) — the base64 is likely truncated/corrupted."
+            exit 1
+          fi
+          # Import into a throwaway keychain and confirm a codesigning identity.
+          KEYCHAIN=verify.keychain
+          KP=$(openssl rand -base64 24)
+          security create-keychain -p "$KP" "$KEYCHAIN"
+          security unlock-keychain -p "$KP" "$KEYCHAIN"
+          if ! security import cert.p12 -k "$KEYCHAIN" -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign; then
+            echo "::error::.p12 import failed — MAC_CERT_PASSWORD is wrong, or the .p12 is corrupted."
+            exit 1
+          fi
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KP" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          echo "── codesigning identities ──"
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          if ! security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "Developer ID Application"; then
+            echo "::error::no 'Developer ID Application' identity in the .p12 — wrong cert type (need Developer ID Application, not Mac App Distribution / Developer ID Installer)."
+            exit 1
+          fi
+          echo "✓ certificate + password valid; Developer ID Application identity present"
+          rm -f cert.p12
+
+      - name: Validate the notarization API key + Apple auth
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${{ secrets.APPLE_API_KEY_P8 }}" > api_key.p8
+          # A .p8 is a PEM private key. A TextEdit-mangled one fails openssl.
+          if ! openssl pkey -in api_key.p8 -noout 2>/dev/null; then
+            echo "::error::APPLE_API_KEY_P8 is not a valid PEM key (likely mangled by an editor). Re-set with: gh secret set APPLE_API_KEY_P8 < AuthKey_XXXX.p8"
+            exit 1
+          fi
+          echo "✓ .p8 is a well-formed PEM key"
+          echo "Key ID: ${APPLE_API_KEY_ID:0:2}…  Issuer: ${APPLE_API_ISSUER:0:8}…  Team: $APPLE_TEAM_ID"
+          # Read-only Apple call that AUTHENTICATES with all four credentials.
+          # Succeeds (even with an empty history) only if key+id+issuer are valid.
+          if ! xcrun notarytool history \
+                --key api_key.p8 \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER" 2>&1 | tee notary.log; then
+            echo "::error::notarytool auth FAILED — one of APPLE_API_KEY_P8 / _KEY_ID / _ISSUER_ID is wrong. See the log above."
+            exit 1
+          fi
+          echo "✓ notarization credentials authenticate against Apple"
+          rm -f api_key.p8
+
+      - name: Summary
+        run: echo "✅ All macOS signing secrets are valid and round-tripped intact. Safe to cut a signed release."


### PR DESCRIPTION
A ~1-min `workflow_dispatch` job to validate the 6 macOS signing secrets round-tripped intact BEFORE spending a real release build — a base64 copied through TextEdit (smart quotes/wrapping) or a mangled `.p8` would otherwise only surface 15 min into the mac build.

Checks: decode + import the `.p12` (cert + password valid, Developer ID Application identity present), `.p8` is a well-formed PEM, and `notarytool history` authenticates against Apple with key-id + issuer (all four notarization creds work together). Builds nothing, submits nothing. Dispatch-only (no auto-trigger).