### PR TITLE
ci: structural .p8 diagnostics in the signing-secrets probe

### DIFF
--- a/.github/workflows/verify_signing_secrets.yml
+++ b/.github/workflows/verify_signing_secrets.yml
@@ -77,9 +77,29 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s' "${{ secrets.APPLE_API_KEY_P8 }}" > api_key.p8
-          # A .p8 is a PEM private key. A TextEdit-mangled one fails openssl.
+          # ── STRUCTURAL diagnostics (no key bytes printed) ──────────────────────
+          # Describe the SHAPE of the .p8 so we can tell WHAT is malformed without
+          # revealing any content. GitHub also masks the secret in logs regardless.
+          bytes=$(wc -c < api_key.p8); lines=$(wc -l < api_key.p8)
+          echo "p8: $bytes bytes, $lines newline(s)"
+          # Header/footer present? (grep -c prints only a count, never the line.)
+          hdr=$(grep -c -- "-----BEGIN PRIVATE KEY-----" api_key.p8 || true)
+          ftr=$(grep -c -- "-----END PRIVATE KEY-----" api_key.p8 || true)
+          echo "has BEGIN header: $([ "$hdr" -ge 1 ] && echo yes || echo NO)"
+          echo "has END footer:   $([ "$ftr" -ge 1 ] && echo yes || echo NO)"
+          # Any NON-ascii bytes (smart quotes / em-dashes from an editor)?
+          if LC_ALL=C grep -qP "[^\x00-\x7F]" api_key.p8 2>/dev/null; then
+            echo "contains NON-ASCII bytes: YES  ← an editor replaced -/quotes; re-set from the raw file"
+          else
+            echo "contains NON-ASCII bytes: no"
+          fi
+          # Any curly/typographic dash where straight - should be?
+          if LC_ALL=C grep -qP "\xe2\x80\x9[0-9a-f]|\xe2\x80\x93|\xe2\x80\x94" api_key.p8 2>/dev/null; then
+            echo "contains typographic dashes/quotes: YES  ← TextEdit smart-substitution"
+          fi
+          # A .p8 is a PEM private key. A mangled one fails openssl.
           if ! openssl pkey -in api_key.p8 -noout 2>/dev/null; then
-            echo "::error::APPLE_API_KEY_P8 is not a valid PEM key (likely mangled by an editor). Re-set with: gh secret set APPLE_API_KEY_P8 < AuthKey_XXXX.p8"
+            echo "::error::APPLE_API_KEY_P8 is not a valid PEM key. See the structural report above. Re-set byte-for-byte with: gh secret set APPLE_API_KEY_P8 < AuthKey_XXXX.p8  (never open the .p8 in TextEdit)."
             exit 1
           fi
           echo "✓ .p8 is a well-formed PEM key"


### PR DESCRIPTION
Adds a shape-only report (byte/line count, BEGIN/END present, non-ASCII / typographic-dash detection) before the openssl check so we can tell WHAT is malformed in APPLE_API_KEY_P8 without revealing any key bytes.