### PR TITLE
Fix updater: channel follows the running build (rc→beta, stable→stable)

### DIFF
--- a/electron/src/main/updater.ts
+++ b/electron/src/main/updater.ts
@@ -8,10 +8,16 @@
  * to detect a new version per platform. Plain vX.Y.Z tags are regular GitHub
  * releases; vX.Y.Z-rc.N/-beta.N tags are marked `prerelease` (release.yml's
  * `channel` job) — `allowPrerelease` is what gates whether autoUpdater will
- * offer those to a given install (see electron-updater's own default: it
- * auto-allows prereleases only when the CURRENTLY INSTALLED version already
- * has a prerelease component, so an explicit stable->beta opt-in needs us to
- * set this ourselves).
+ * offer those to a given install.
+ *
+ * CHANNEL DEFAULT FOLLOWS THE RUNNING BUILD. The default channel is derived from
+ * THIS build's own version: a prerelease build (…-rc.N) tracks beta, a plain
+ * X.Y.Z tracks stable (defaultChannelForVersion in updater_errors.ts). So an rc
+ * install checks the beta feed (where its updates actually are) instead of the
+ * stable feed — which, with no stable release published yet, would 404 and error.
+ * An explicit user choice (the dialog radio, persisted) always overrides the
+ * default. And a "no release for this channel" result is reported as up-to-date,
+ * not an error (isNoReleaseForChannel).
  *
  * autoDownload is OFF: check -> tell the renderer -> user clicks "Download" ->
  * we call downloadUpdate() -> "Restart to install" -> quitAndInstall(). This
@@ -29,7 +35,7 @@ import { app, BrowserWindow } from 'electron'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { autoUpdater } from 'electron-updater'
-import { friendlyError } from './updater_errors'
+import { friendlyError, defaultChannelForVersion } from './updater_errors'
 
 export type UpdateChannel = 'stable' | 'beta'
 
@@ -96,15 +102,30 @@ export function getLastUpdateStatus(): UpdateStatus {
   return lastStatus
 }
 
-/** Read the persisted channel choice (defaults to 'stable'). Electron-side
- *  storage, separate from ~/.spyde/settings.json — updater.ts must be able to
- *  read this before the Python sidecar is necessarily up. */
+/** Read the effective update channel. An EXPLICIT persisted choice (the user
+ *  flipped the radio) always wins; otherwise the default follows the RUNNING
+ *  build's own version — a prerelease build (…-rc.N) tracks beta, a plain X.Y.Z
+ *  tracks stable. This is what stops an rc install from fruitlessly checking the
+ *  (non-existent) stable channel and erroring. Electron-side storage, separate
+ *  from ~/.spyde/settings.json — readable before the Python sidecar is up. */
 export function readUpdateChannel(): UpdateChannel {
   try {
     const raw = readFileSync(channelFilePath, 'utf8').trim()
-    return raw === 'beta' ? 'beta' : 'stable'
+    if (raw === 'beta' || raw === 'stable') return raw
+    // Any other/empty content → fall through to the version-derived default.
   } catch {
-    return 'stable'
+    // No persisted choice yet → derive from this build's version.
+  }
+  return defaultChannelForVersion(appVersion())
+}
+
+/** The running app's version. Wrapped so it's overridable/testable and safe if
+ *  called before `app` is ready (falls back to a stable-looking version). */
+function appVersion(): string {
+  try {
+    return app.getVersion()
+  } catch {
+    return '0.0.0'
   }
 }
 
@@ -157,9 +178,32 @@ export function initUpdater(mainWindow: BrowserWindow, userData: string): void {
     sendStatus({ state: 'downloaded', version: info.version })
   })
 
-  // electron-updater surfaces network + verification failures here. Route
-  // through reportError so the state is left recheckable + the message friendly.
-  autoUpdater.on('error', (err) => reportError(err?.message ?? String(err)))
+  // electron-updater surfaces network + verification failures here. But a
+  // "no release found for this channel" error (e.g. a STABLE build/channel when
+  // only prereleases exist yet — no stable release published) is NOT a failure —
+  // it means "you're up to date on your channel". Report THAT as not-available so
+  // the user sees a calm "up to date", not a scary error. Everything else routes
+  // through reportError (friendly + recheckable).
+  autoUpdater.on('error', (err) => {
+    const msg = err?.message ?? String(err)
+    if (isNoReleaseForChannel(msg)) {
+      checkInFlight = false
+      clearCheckTimer()
+      sendStatus({ state: 'not-available' })
+      return
+    }
+    reportError(msg)
+  })
+}
+
+/** Recognise electron-updater's "there is no release matching this channel" error
+ *  — the feed / release simply doesn't exist for the channel we asked for (a
+ *  stable build when only prereleases have shipped). That's "up to date", not a
+ *  fault. Kept conservative: only the shapes electron-updater/GitHubProvider emit
+ *  for a genuinely-absent release, so a real 404-from-network still surfaces. */
+function isNoReleaseForChannel(msg: string): boolean {
+  const s = String(msg || '')
+  return /Unable to find latest version on GitHub|No published versions on GitHub|latest-mac\.yml.*not found|Cannot find channel|No version found/i.test(s)
 }
 
 /** (Re)arm the download stall watchdog: if no progress event lands within

--- a/electron/src/main/updater_errors.test.ts
+++ b/electron/src/main/updater_errors.test.ts
@@ -10,7 +10,9 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { friendlyError, truncateMessage } from './updater_errors.ts'
+import {
+  friendlyError, truncateMessage, isPrereleaseVersion, defaultChannelForVersion,
+} from './updater_errors.ts'
 
 test('offline / DNS errors → offline message', () => {
   for (const raw of ['net::ERR_INTERNET_DISCONNECTED', 'getaddrinfo ENOTFOUND github.com', 'EAI_AGAIN']) {
@@ -77,4 +79,33 @@ test('empty / nullish input → empty string, never throws', () => {
   assert.equal(friendlyError(null), '')
   // @ts-expect-error deliberately exercising an undefined raw
   assert.equal(friendlyError(undefined), '')
+})
+
+// ── channel detection (rc build → beta, stable build → stable) ────────────────
+
+test('prerelease versions are detected', () => {
+  for (const v of ['0.2.0-rc.8', '0.2.0-rc.1', '1.0.0-beta.2', '2.3.4-alpha.1',
+                   'v0.2.0-rc.8', '0.2.0-rc.8+build.5']) {
+    assert.equal(isPrereleaseVersion(v), true, `${v} should be prerelease`)
+  }
+})
+
+test('plain releases are NOT prerelease', () => {
+  for (const v of ['0.2.0', '1.0.0', 'v2.3.4', '0.2.0+build.5', '10.20.30']) {
+    assert.equal(isPrereleaseVersion(v), false, `${v} should be stable`)
+  }
+})
+
+test('defaultChannelForVersion: rc build → beta, stable build → stable', () => {
+  assert.equal(defaultChannelForVersion('0.2.0-rc.8'), 'beta')
+  assert.equal(defaultChannelForVersion('v1.0.0-beta.1'), 'beta')
+  assert.equal(defaultChannelForVersion('0.2.0'), 'stable')
+  assert.equal(defaultChannelForVersion('1.2.3'), 'stable')
+})
+
+test('channel detection tolerates empty/garbage version', () => {
+  assert.equal(isPrereleaseVersion(''), false)
+  // @ts-expect-error nullish
+  assert.equal(isPrereleaseVersion(null), false)
+  assert.equal(defaultChannelForVersion(''), 'stable')
 })

--- a/electron/src/main/updater_errors.ts
+++ b/electron/src/main/updater_errors.ts
@@ -1,13 +1,33 @@
 /**
- * updater_errors.ts — PURE, dependency-free error mapping for the auto-updater.
+ * updater_errors.ts — PURE, dependency-free updater helpers (error mapping +
+ * channel detection).
  *
  * Split out of updater.ts (which imports `electron`, so it can't be loaded by a
- * plain node unit test) so `friendlyError` can be unit-tested with `node:test` on
- * every CI push, on every OS. The whole point: an updater error must NEVER reach
- * the UI as a raw blob — the "mac auto-update failed spectacularly" screenshot was
- * ~10 KB of raw releases.atom XML rendered full-screen because the fallback
- * returned the provider's message verbatim. See updater_errors.test.ts.
+ * plain node unit test) so these can be unit-tested with `node:test` on every CI
+ * push, on every OS. The whole point of friendlyError: an updater error must NEVER
+ * reach the UI as a raw blob — the "mac auto-update failed spectacularly"
+ * screenshot was ~10 KB of raw releases.atom XML rendered full-screen because the
+ * fallback returned the provider's message verbatim. See updater_errors.test.ts.
  */
+
+/** True when a semver string has a prerelease component (-rc.N / -beta.N /
+ *  -alpha.N / any `-suffix`). Used to pick the DEFAULT update channel from the
+ *  running build's OWN version: a prerelease build follows the beta channel, a
+ *  plain X.Y.Z follows stable — so an rc build never fruitlessly looks for a
+ *  (non-existent) stable release. Tolerant of a leading `v` and build metadata
+ *  (`+…`). */
+export function isPrereleaseVersion(version: string): boolean {
+  const v = String(version ?? '').trim().replace(/^v/i, '')
+  // Strip build metadata, then a prerelease is anything after the first '-'.
+  const core = v.split('+')[0]
+  return core.includes('-')
+}
+
+/** The channel a build should follow BY DEFAULT (before any explicit user
+ *  choice): beta if the running build is itself a prerelease, else stable. */
+export function defaultChannelForVersion(version: string): 'stable' | 'beta' {
+  return isPrereleaseVersion(version) ? 'beta' : 'stable'
+}
 
 /** Bound an unrecognised error message so a huge single-line payload can't blow
  *  out the error box. Collapse whitespace, cap length, keep it one readable line. */


### PR DESCRIPTION
The updater channel defaulted to \`stable\`, so an **rc install checked the stable feed** — which doesn't exist yet (only prereleases have shipped) → the update check **errored**. This is the "no stable release throws an error" bug.

## Fix
- **Default channel follows THIS build's version:** a prerelease build (\`…-rc.N\`/\`-beta.N\`/\`-alpha.N\`) tracks **beta**; a plain \`X.Y.Z\` tracks **stable** (\`defaultChannelForVersion\` / \`isPrereleaseVersion\`, pure + unit-tested cross-OS). An explicit user choice (dialog radio, persisted) still overrides.
- **"No release for this channel" → up-to-date, not error** (\`isNoReleaseForChannel\`): a stable build with no stable release yet says "you're up to date" instead of failing.

## Tests
4 new \`node:test\` cases (rc→beta, stable→stable, garbage-tolerant). Typecheck + build clean.

Note: this ships in the NEXT build; existing rc.8 installs already have the old default baked in, so they may still need one manual update to a build containing this fix.